### PR TITLE
View model implementation for dashboard

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.100
+        dotnet-version: 5.0
     
     - name: Build
       run: dotnet build --configuration Release

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0
+        dotnet-version: 3.1.100
     
     - name: Build
       run: dotnet build --configuration Release

--- a/src/core/Portfolio/Handlers/Get.cs
+++ b/src/core/Portfolio/Handlers/Get.cs
@@ -38,11 +38,12 @@ namespace core.Portfolio
             public override async Task<PortfolioResponse> Handle(Query request, CancellationToken cancellationToken)
             {
                 var fromCache = await _storage.ViewModel<PortfolioResponse>(request.UserId);
+                if (fromCache != null)
+                {
+                    return fromCache;
+                }
 
-                return fromCache switch {
-                    not null => fromCache,
-                    null => await GetFromDatabase(request.UserId)
-                };
+                return await GetFromDatabase(request.UserId);
             }
 
             public async Task Handle(UserRecalculate notification, CancellationToken cancellationToken)

--- a/src/core/Portfolio/Handlers/Get.cs
+++ b/src/core/Portfolio/Handlers/Get.cs
@@ -69,7 +69,8 @@ namespace core.Portfolio
                     OwnedStockCount = owned.Count(),
                     OpenOptionCount = openOptions.Count(),
                     TriggeredAlertCount = _alerts.Monitors.Count(s => s.Alert.UserId == userId && s.IsTriggered),
-                    AlertCount = _alerts.Monitors.Count(s => s.Alert.UserId == userId)
+                    AlertCount = _alerts.Monitors.Count(s => s.Alert.UserId == userId),
+                    Calculated = DateTimeOffset.UtcNow
                 };
                 return obj;
             }

--- a/src/core/Portfolio/IPortfolioStorage.cs
+++ b/src/core/Portfolio/IPortfolioStorage.cs
@@ -10,6 +10,7 @@ namespace core
     public interface IPortfolioStorage
     {
         Task<T> ViewModel<T>(Guid userId);
+        Task SaveViewModel<T>(Guid userId, T model);
 
         Task<OwnedStock> GetStock(string ticker, Guid userId);
         Task<OwnedStock> GetStock(Guid id, Guid userId);

--- a/src/core/Portfolio/IPortfolioStorage.cs
+++ b/src/core/Portfolio/IPortfolioStorage.cs
@@ -9,6 +9,8 @@ namespace core
 {
     public interface IPortfolioStorage
     {
+        Task<T> ViewModel<T>(Guid userId);
+
         Task<OwnedStock> GetStock(string ticker, Guid userId);
         Task<OwnedStock> GetStock(Guid id, Guid userId);
         Task<IEnumerable<OwnedStock>> GetStocks(Guid userId);

--- a/src/core/Portfolio/Output/PortfolioResponse.cs
+++ b/src/core/Portfolio/Output/PortfolioResponse.cs
@@ -2,9 +2,9 @@ namespace core.Portfolio.Output
 {
     public class PortfolioResponse
     {
-        public int OwnedStockCount { get; internal set; }
-        public int OpenOptionCount { get; internal set; }
-        public int TriggeredAlertCount { get; internal set; }
-        public int AlertCount { get; internal set; }
+        public int OwnedStockCount { get; set; }
+        public int OpenOptionCount { get; set; }
+        public int TriggeredAlertCount { get; set; }
+        public int AlertCount { get; set; }
     }
 }

--- a/src/core/Portfolio/Output/PortfolioResponse.cs
+++ b/src/core/Portfolio/Output/PortfolioResponse.cs
@@ -1,10 +1,14 @@
+using System;
+using core.Shared;
+
 namespace core.Portfolio.Output
 {
-    public class PortfolioResponse
+    public class PortfolioResponse : IViewModel
     {
         public int OwnedStockCount { get; set; }
         public int OpenOptionCount { get; set; }
         public int TriggeredAlertCount { get; set; }
         public int AlertCount { get; set; }
+        public DateTimeOffset Calculated { get; set; }
     }
 }

--- a/src/core/Portfolio/Output/PortfolioResponse.cs
+++ b/src/core/Portfolio/Output/PortfolioResponse.cs
@@ -1,0 +1,10 @@
+namespace core.Portfolio.Output
+{
+    public class PortfolioResponse
+    {
+        public int OwnedStockCount { get; internal set; }
+        public int OpenOptionCount { get; internal set; }
+        public int TriggeredAlertCount { get; internal set; }
+        public int AlertCount { get; internal set; }
+    }
+}

--- a/src/core/Shared/IViewModel.cs
+++ b/src/core/Shared/IViewModel.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace core.Shared
+{
+    public interface IViewModel
+    {
+        DateTimeOffset Calculated { get; }
+    }
+}

--- a/src/core/Shared/UserRecalculate.cs
+++ b/src/core/Shared/UserRecalculate.cs
@@ -1,0 +1,15 @@
+using System;
+using MediatR;
+
+namespace core.Shared
+{
+    public class UserRecalculate : INotification
+    {
+        public UserRecalculate(Guid userId)
+        {
+            UserId = userId;
+        }
+
+        public Guid UserId { get; }
+    }
+}

--- a/src/core/core.csproj
+++ b/src/core/core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>Latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/infrastructure/storage.redis/RedisAggregateStorage.cs
+++ b/src/infrastructure/storage.redis/RedisAggregateStorage.cs
@@ -4,12 +4,13 @@ using System.Linq;
 using System.Threading.Tasks;
 using core.Shared;
 using MediatR;
+using Newtonsoft.Json;
 using StackExchange.Redis;
 using storage.shared;
 
 namespace storage.redis
 {
-    public class RedisAggregateStorage : IAggregateStorage
+    public class RedisAggregateStorage : IAggregateStorage, IBlobStorage
     {
         private IMediator _mediator;
         protected ConnectionMultiplexer _redis;
@@ -18,6 +19,22 @@ namespace storage.redis
         {
             _mediator = mediator;
             _redis = ConnectionMultiplexer.Connect(redisCnn);
+        }
+
+        public async Task<T> Get<T>(string key)
+        {
+            var redisKey = typeof(T).Name + ":" + key;
+
+            var db = _redis.GetDatabase();
+
+            var val = await db.StringGetAsync(redisKey);
+
+            return val.HasValue ? JsonConvert.DeserializeObject<T>(val) : default(T);
+        }
+
+        public Task Save<T>(string key, T t)
+        {
+            throw new NotImplementedException();
         }
 
         public async Task<IEnumerable<AggregateEvent>> GetEventsAsync(string entity, Guid userId)

--- a/src/infrastructure/storage.shared/IBlobStorage.cs
+++ b/src/infrastructure/storage.shared/IBlobStorage.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+
+namespace storage.shared
+{
+    public interface IBlobStorage
+    {
+        Task<T> Get<T>(string key);
+        Task Save<T>(string key, T t);
+    }
+}

--- a/src/infrastructure/storage.shared/PortfolioStorage.cs
+++ b/src/infrastructure/storage.shared/PortfolioStorage.cs
@@ -32,6 +32,11 @@ namespace storage.shared
             return _blobStorage.Get<T>(typeof(T).Name + "#" + userId);
         }
 
+        public Task SaveViewModel<T>(Guid userId, T t)
+        {
+            return _blobStorage.Save<T>(typeof(T).Name + "#" + userId, t);
+        }
+
         public async Task<OwnedStock> GetStock(string ticker, Guid userId)
         {
             var stocks = await GetStocks(userId);

--- a/src/infrastructure/storage.shared/PortfolioStorage.cs
+++ b/src/infrastructure/storage.shared/PortfolioStorage.cs
@@ -17,10 +17,19 @@ namespace storage.shared
         private const string _note_entity = "note3";
 
         private IAggregateStorage _aggregateStorage;
+        private IBlobStorage _blobStorage;
 
-        public PortfolioStorage(IAggregateStorage aggregateStorage)
+        public PortfolioStorage(
+            IAggregateStorage aggregateStorage,
+            IBlobStorage blobStorage)
         {
             _aggregateStorage = aggregateStorage;
+            _blobStorage = blobStorage;
+        }
+
+        public Task<T> ViewModel<T>(Guid userId)
+        {
+            return _blobStorage.Get<T>(typeof(T).Name + "#" + userId);
         }
 
         public async Task<OwnedStock> GetStock(string ticker, Guid userId)

--- a/src/web/ClientApp/src/app/dashboard/dashboard.component.html
+++ b/src/web/ClientApp/src/app/dashboard/dashboard.component.html
@@ -12,7 +12,7 @@
       </div>
     </div>
 
-    <div class="row" *ngIf="openOptions.length == 0 && owned.length == 0">
+    <div class="row" *ngIf="dashboard.openOptionCount == 0 && dashboard.openStockCount == 0">
       <div class="col">
         <div class="alert alert-secondary">
           <h3>Welcome!</h3>
@@ -37,7 +37,7 @@
               <i class="fas fa-certificate"></i>
               Shares
             </h5>
-            <p class="card-text">You have <b>{{owned.length}}</b> tickers on file</p>
+            <p class="card-text">You have <b>{{dashboard.ownedStockCount}}</b> tickers on file</p>
             <a class="card-link" [routerLink]="[ '/stocks' ]">Manage Shares</a>
           </div>
         </div>
@@ -48,7 +48,7 @@
               <i class="fas fa-dice-five"></i>
               Options
             </h5>
-            <p class="card-text">You have <b>{{openOptions.length}}</b> open contracts</p>
+            <p class="card-text">You have <b>{{dashboard.openOptionCount}}</b> open contracts</p>
             <a class="card-link" [routerLink]="[ '/options' ]">Manage Options</a>
           </div>
         </div>
@@ -73,7 +73,7 @@
               <i class="fas fa-bell"></i>
               Alerts
             </h5>
-            <p class="card-text">Triggered: <b>{{triggered.length}}</b>, total: <b>{{alerts.length}}</b></p>
+            <p class="card-text">Triggered: <b>{{dashboard.triggeredAlertCount}}</b>, total: <b>{{dashboard.alertCount}}</b></p>
             <a class="card-link" [routerLink]="[ '/alerts' ]">Visit Alerts</a>
           </div>
         </div>

--- a/src/web/ClientApp/src/app/dashboard/dashboard.component.ts
+++ b/src/web/ClientApp/src/app/dashboard/dashboard.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
-import { StocksService, OwnedStock, OwnedOption, Alert } from '../services/stocks.service';
+import { StocksService, OwnedStock, OwnedOption, Alert, Dashboard } from '../services/stocks.service';
 
 
 @Component({
@@ -10,20 +10,8 @@ import { StocksService, OwnedStock, OwnedOption, Alert } from '../services/stock
 })
 export class DashboardComponent implements OnInit {
 
-	owned : OwnedStock[]
-  openOptions : OwnedOption[]
-  alerts: Alert[]
-  triggered: Alert[]
+	dashboard : Dashboard
   loaded : boolean = false
-
-  numberOfSharesOwned: number;
-  moneySpentOnShares: number;
-  currentEquity: number;
-  profits: number;
-  optionPremium: number;
-  putContracts: number;
-  callContracts: number;
-  putCollateral: number;
 
 	constructor(
 		private stocks : StocksService,
@@ -33,13 +21,8 @@ export class DashboardComponent implements OnInit {
 	ngOnInit() {
 
 		this.stocks.getPortfolio().subscribe(result => {
-      this.owned = result.owned;
-      this.openOptions = result.openOptions
-      this.alerts = result.alerts
-      this.triggered = result.triggered
+      this.dashboard = result;
       this.loaded = true;
-      this.calculateProperties();
-      this.sort("profits")
 		}, error => {
 			console.log(error);
 			this.loaded = false;
@@ -48,90 +31,5 @@ export class DashboardComponent implements OnInit {
 
   onTickerSelected(ticker:string) {
     this.router.navigateByUrl('/stocks/' + ticker)
-  }
-
-  calculateProperties() {
-
-    this.numberOfSharesOwned = 0.0
-    this.moneySpentOnShares = 0.0
-    this.currentEquity = 0.0
-
-    for (var i of this.owned) {
-      this.numberOfSharesOwned += i.owned
-      this.moneySpentOnShares += i.cost
-      this.currentEquity += i.equity
-    }
-
-    this.profits = 0.0
-    if (this.moneySpentOnShares != 0) {
-      var made = this.currentEquity - this.moneySpentOnShares
-      this.profits = made / this.moneySpentOnShares
-    }
-
-    this.optionPremium = 0.0
-    this.putContracts = 0
-    this.callContracts = 0
-    this.putCollateral = 0
-    var putPremium = 0
-    for (var o of this.openOptions) {
-      this.optionPremium += o.profit
-      if (o.optionType == "PUT")
-      {
-        this.putContracts++
-        putPremium += o.profit
-
-        if (o.boughtOrSold == 'Sold')
-        {
-          this.putCollateral += (o.strikePrice * 100)
-        }
-      }
-
-      if (o.optionType == "CALL")
-      {
-        this.callContracts++
-      }
-    }
-  }
-
-  sortColumn : string
-  sortDirection : number = -1
-
-  sort(column:string) {
-
-    var func = this.getSortFunc(column);
-
-    if (this.sortColumn != column) {
-      this.sortDirection = -1
-    } else {
-      this.sortDirection *= -1
-    }
-    this.sortColumn = column
-
-    var finalFunc = (a, b) => {
-      var result = func(a, b)
-      return result * this.sortDirection
-    }
-
-    this.owned.sort(finalFunc)
-  }
-
-  private getSortFunc(column:string) {
-    switch(column) {
-      case "ticker":
-        return (a:OwnedStock, b:OwnedStock) => a.ticker.localeCompare(b.ticker)
-      case "averageCost":
-        return (a:OwnedStock, b:OwnedStock) => a.averageCost - b.averageCost
-      case "owned":
-        return (a:OwnedStock, b:OwnedStock) => a.owned - b.owned
-      case "equity":
-        return (a:OwnedStock, b:OwnedStock) => a.equity - b.equity
-      case "profits":
-        return (a:OwnedStock, b:OwnedStock) => a.profits - b.profits
-      case "profitsPct":
-        return (a:OwnedStock, b:OwnedStock) => a.profitsPct - b.profitsPct
-    }
-
-    console.log("unrecognized sort column " + column)
-    return null;
   }
 }

--- a/src/web/ClientApp/src/app/services/stocks.service.ts
+++ b/src/web/ClientApp/src/app/services/stocks.service.ts
@@ -157,8 +157,8 @@ export class StocksService {
 
   // ------- portfolio ----------------
 
-  getPortfolio(): Observable<Portfolio> {
-		return this.http.get<Portfolio>('/api/portfolio')
+  getPortfolio(): Observable<Dashboard> {
+		return this.http.get<Dashboard>('/api/portfolio')
   }
 
   // ------- options ----------------
@@ -306,6 +306,13 @@ export class OwnedStock {
 }
 
 export class Alert {}
+
+export class Dashboard {
+  openOptionCount: number
+  ownedStockCount: number
+  triggeredAlertCount: number
+  alertCount: number
+}
 
 export class OwnedOption {
   id:string

--- a/src/web/Controllers/PortfolioController.cs
+++ b/src/web/Controllers/PortfolioController.cs
@@ -23,7 +23,7 @@ namespace web.Controllers
         }
 
         [HttpGet]
-        public Task<object> Index()
+        public Task<PortfolioResponse> Index()
         {
             var query = new Get.Query(this.User.Identifier());
 

--- a/src/web/DIHelper.cs
+++ b/src/web/DIHelper.cs
@@ -88,6 +88,10 @@ namespace web
             {
                 return new storage.redis.RedisAggregateStorage(s.GetRequiredService<IMediator>(), cnn);
             });
+            services.AddSingleton<IBlobStorage>(s => 
+            {
+                return new storage.redis.RedisAggregateStorage(s.GetRequiredService<IMediator>(), cnn);
+            });
             services.AddSingleton<storage.redis.RedisAggregateStorage>(c => 
                 (storage.redis.RedisAggregateStorage)c.GetService<IAggregateStorage>());
             services.AddSingleton<Migration>(_ =>

--- a/src/web/StockMonitorService.cs
+++ b/src/web/StockMonitorService.cs
@@ -85,16 +85,12 @@ namespace web
             var time = DateTimeOffset.UtcNow;
             if (_marketHours.IsOn(time))
             {
-                _logger.LogInformation($"market hours {time.TimeOfDay}");
-
                 await ScanAlerts();
 
                 await Task.Delay(LONG_INTERVAL, stoppingToken);
             }
             else
             {
-                _logger.LogInformation($"non market hours {time.TimeOfDay}");
-
                 await Task.Delay(SHORT_INTERVAL, stoppingToken);
             }
         }

--- a/tests/coretests/Fakes/FakePortfolioStorage.cs
+++ b/tests/coretests/Fakes/FakePortfolioStorage.cs
@@ -83,5 +83,15 @@ namespace coretests.Fakes
         {
             throw new NotImplementedException();
         }
+
+        public Task<T> ViewModel<T>(Guid userId)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task SaveViewModel<T>(Guid userId, T model)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/tests/storagetests/postgres/PostgresPortfolioStorageTests.cs
+++ b/tests/storagetests/postgres/PostgresPortfolioStorageTests.cs
@@ -14,7 +14,9 @@ namespace storagetests.postgres
         protected override IPortfolioStorage CreateStorage()
         {
             return new PortfolioStorage(
-                new PostgresAggregateStorage(new Fakes.FakeMediator(), _cnn));
+                new PostgresAggregateStorage(new Fakes.FakeMediator(), _cnn),
+                null
+            );
         }
     }
 }

--- a/tests/storagetests/redis/RedisPortfolioStorageTests.cs
+++ b/tests/storagetests/redis/RedisPortfolioStorageTests.cs
@@ -11,10 +11,12 @@ namespace storagetests.redis
     {
         protected override IPortfolioStorage CreateStorage()
         {
-            return new PortfolioStorage(
-                new RedisAggregateStorage(
-                    new Fakes.FakeMediator(),
-                    "localhost"));
+            var redisStorage = new RedisAggregateStorage(
+                new Fakes.FakeMediator(),
+                "localhost"
+            );
+
+            return new PortfolioStorage(redisStorage, redisStorage);
         }
     }
 }

--- a/todo.txt
+++ b/todo.txt
@@ -1,9 +1,9 @@
 Generate view models for various stocks, I think it's time my friend :)
 
 - Dashboard
-    number of stocks
-    number of options
-    alerts triggered
+    - trigger rebuild when any new stock is added/closed
+    - trigger rebuild when any new option is added/closed
+    - 
 
 Upcoming earnings in watch/holdings
 Upcoming expirations in options


### PR DESCRIPTION
Trying out calculated user's view model and storing it in the cache to avoid repeated iteration over the views.

It's very to the point and crude implementation. Aggregate storage sends an event to recalculate user view models whenever user's aggregate is saved. We are being very dumb and not choosy which model needs to be recalculated. We recalculate them all.