### PR TITLE
Thirty day heads up

### DIFF
--- a/src/core/Reports/Sells.cs
+++ b/src/core/Reports/Sells.cs
@@ -1,49 +1,31 @@
 using System;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using core.Reports.Views;
 using core.Shared;
-using core.Stocks;
 
 namespace core.Reports
 {
     public class Sells
     {
-        public class Query : RequestWithUserId<object>
+        public class Query : RequestWithUserId<SellsView>
         {
             public Query(Guid userId) : base(userId)
             {
             }
         }
 
-        public class Handler : HandlerWithStorage<Query, object>
+        public class Handler : HandlerWithStorage<Query, SellsView>
         {
             public Handler(IPortfolioStorage storage) : base(storage)
             {
             }
 
-            public override async Task<object> Handle(Query request, CancellationToken cancellationToken)
+            public override async Task<SellsView> Handle(Query request, CancellationToken cancellationToken)
             {
                 var stocks = await _storage.GetStocks(request.UserId);
 
-                var sells = stocks
-                    .SelectMany(s => s.State.BuyOrSell.Select(t => new { stock = s, buyOrSell = t}))
-                    .Where(s => s.buyOrSell is StockSold)
-                    .Where(s => s.buyOrSell.When > DateTimeOffset.UtcNow.AddDays(-60))
-                    .GroupBy(s => s.stock.State.Ticker)
-                    .Select(g => new {ticker = g.Key, latest = g.OrderByDescending(s => s.buyOrSell.When).First()})
-                    .Select(t => new 
-                    {
-                        ticker = t.ticker,
-                        date = t.latest.buyOrSell.When,
-                        numberOfShares = t.latest.buyOrSell.NumberOfShares,
-                        price = t.latest.buyOrSell.Price,
-                        olderThan30Days = t.latest.buyOrSell.When < DateTimeOffset.UtcNow.AddDays(-30)
-                    })
-                    .OrderByDescending(a => a.date)
-                    .ToList();
-
-                return sells;
+                return new SellsView(stocks);
             }
         }
     }

--- a/src/core/Reports/Views/SellView.cs
+++ b/src/core/Reports/Views/SellView.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace core.Reports.Views
+{
+    public class SellView
+    {
+        public string Ticker { get; set; }
+        public DateTimeOffset Date { get; set; }
+        public int NumberOfShares { get; set; }
+        public double Price { get; set; }
+        public bool OlderThan30Days { get; set; }
+    }
+}

--- a/src/core/Reports/Views/SellView.cs
+++ b/src/core/Reports/Views/SellView.cs
@@ -9,5 +9,6 @@ namespace core.Reports.Views
         public int NumberOfShares { get; set; }
         public double Price { get; set; }
         public bool OlderThan30Days { get; set; }
+        public int NumberOfDays => (int)Math.Floor(DateTimeOffset.UtcNow.Subtract(Date).TotalDays);
     }
 }

--- a/src/core/Reports/Views/SellsView.cs
+++ b/src/core/Reports/Views/SellsView.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using core.Stocks;
+
+namespace core.Reports.Views
+{
+    public class SellsView
+    {
+        public SellsView(IEnumerable<OwnedStock> stocks)
+        {
+            Sells = stocks
+                    .SelectMany(s => s.State.BuyOrSell.Select(t => new { stock = s, buyOrSell = t}))
+                    .Where(s => s.buyOrSell is StockSold)
+                    .Where(s => s.buyOrSell.When > DateTimeOffset.UtcNow.AddDays(-60))
+                    .GroupBy(s => s.stock.State.Ticker)
+                    .Select(g => new {ticker = g.Key, latest = g.OrderByDescending(s => s.buyOrSell.When).First()})
+                    .Select(t => new SellView
+                    {
+                        Ticker = t.ticker,
+                        Date = t.latest.buyOrSell.When,
+                        NumberOfShares = t.latest.buyOrSell.NumberOfShares,
+                        Price = t.latest.buyOrSell.Price,
+                        OlderThan30Days = t.latest.buyOrSell.When < DateTimeOffset.UtcNow.AddDays(-30)
+                    })
+                    .OrderByDescending(a => a.Date)
+                    .ToList();
+        }
+
+        public List<SellView> Sells { get; }
+    }
+}

--- a/src/core/Shared/Adapters/Emails/EmailSettings.cs
+++ b/src/core/Shared/Adapters/Emails/EmailSettings.cs
@@ -37,7 +37,7 @@ namespace core.Adapters.Emails
 
         public static EmailTemplate NewUserWelcome = new EmailTemplate("d-7fe69a3b1f164830b82112dc10c745b0");
 
-        public static EmailTemplate SellAlert = new EmailTemplate("d-7fe69a3b1f164830b82112dc10c745b0");
+        public static EmailTemplate SellAlert = new EmailTemplate("d-a8ac152d334d471aaab2fead90a8f120");
 
         public EmailTemplate(string id)
         {

--- a/src/core/Shared/Adapters/Emails/EmailSettings.cs
+++ b/src/core/Shared/Adapters/Emails/EmailSettings.cs
@@ -37,6 +37,8 @@ namespace core.Adapters.Emails
 
         public static EmailTemplate NewUserWelcome = new EmailTemplate("d-7fe69a3b1f164830b82112dc10c745b0");
 
+        public static EmailTemplate SellAlert = new EmailTemplate("d-7fe69a3b1f164830b82112dc10c745b0");
+
         public EmailTemplate(string id)
         {
             Id = id;

--- a/src/core/Stocks/OwnedStockState.cs
+++ b/src/core/Stocks/OwnedStockState.cs
@@ -26,7 +26,7 @@ namespace core.Stocks
         public int DaysHeld { get; private set; }
         public int DaysSinceLastTransaction { get; private set; }
         public IEnumerable<AggregateEvent> UndeletedBuysOrSells =>
-            BuyOrSell.Where(a => Deletes.Contains(a.Id)).Cast<AggregateEvent>();
+            BuyOrSell.Where(a => Deletes.Contains(a.Id) == false).Cast<AggregateEvent>();
 
         internal void ApplyInternal(TickerObtained o)
         {

--- a/src/core/Stocks/OwnedStockState.cs
+++ b/src/core/Stocks/OwnedStockState.cs
@@ -161,7 +161,8 @@ namespace core.Stocks
 
                 _ = st switch {
                     StockPurchased => PurchaseProcessing(st),
-                    StockSold => SellProcessing(st)
+                    StockSold => SellProcessing(st),
+                    _ => throw new InvalidOperationException("Unhandled type")
                 };
 
                 if (owned == 0)

--- a/src/core/Stocks/OwnedStockState.cs
+++ b/src/core/Stocks/OwnedStockState.cs
@@ -159,12 +159,15 @@ namespace core.Stocks
                     continue;
                 }
 
-                _ = st switch {
-                    StockPurchased => PurchaseProcessing(st),
-                    StockSold => SellProcessing(st),
-                    _ => throw new InvalidOperationException("Unhandled type")
-                };
-
+                if (st is StockPurchased sp)
+                {
+                    PurchaseProcessing(sp);
+                }
+                else if (st is StockSold ss)
+                {
+                    SellProcessing(ss);
+                }
+                
                 if (owned == 0)
                 {
                     avgCost = 0;

--- a/src/infrastructure/iexclient/IEXClient.cs
+++ b/src/infrastructure/iexclient/IEXClient.cs
@@ -122,7 +122,7 @@ namespace iexclient
 
             if (!r.IsSuccessStatusCode)
             {
-                _logger.LogError($"Failed to get stocks with url {url}: " + response);
+                _logger?.LogError($"Failed to get stocks with url {url}: " + response);
                 r.EnsureSuccessStatusCode();
             }
 

--- a/src/infrastructure/sendgridclient/SendGridClientImpl.cs
+++ b/src/infrastructure/sendgridclient/SendGridClientImpl.cs
@@ -48,10 +48,9 @@ namespace sendgridclient
             
             var response = await client.SendEmailAsync(msg);
 
-            var json = msg.Serialize();
+            var err = await response.Body.ReadAsStringAsync();
 
-            Console.WriteLine("Sendgrid response: " + response.StatusCode);
-            Console.WriteLine(json);
+            Console.WriteLine($"Sendgrid status {response.StatusCode} with body: {err}");
         }
     }
 }

--- a/src/web/BackgroundServices/StockMonitorService.cs
+++ b/src/web/BackgroundServices/StockMonitorService.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using web.Utils;
 
-namespace web
+namespace web.BackgroundServices
 {
     public class StockMonitorService : BackgroundService
     {

--- a/src/web/BackgroundServices/ThirtyDaySellService.cs
+++ b/src/web/BackgroundServices/ThirtyDaySellService.cs
@@ -83,12 +83,7 @@ namespace web.BackgroundServices
 
                 if (sellsOfInterest.Count == 0)
                 {
-                    sellsOfInterest.Add(new SellView {
-                        Ticker = "FSLY",
-                        Price = 37,
-                        Date = new DateTimeOffset(year: 2021, month: 8, day: 22, hour: 0, minute: 0, second: 1, offset: TimeSpan.Zero)
-                    });
-                    // continue;
+                    continue;
                 }
 
                 await _emails.Send(

--- a/src/web/BackgroundServices/ThirtyDaySellService.cs
+++ b/src/web/BackgroundServices/ThirtyDaySellService.cs
@@ -66,7 +66,7 @@ namespace web.BackgroundServices
             foreach(var p in pairs)
             {
                 // 30 day crosser
-                var crossers = new List<SellView>();
+                var sellsOfInterest = new List<SellView>();
                 var query = new Sells.Query(new Guid(p.id));
 
                 var sellView = await _mediator.Send(query);
@@ -75,7 +75,7 @@ namespace web.BackgroundServices
                 {
                     if (s.Date.Date == DateTime.UtcNow)
                     {
-                        crossers.Add(s);
+                        sellsOfInterest.Add(s);
                     }
                 }
 
@@ -83,7 +83,7 @@ namespace web.BackgroundServices
                     recipient: p.email,
                     Sender.NoReply,
                     template: EmailTemplate.SellAlert,
-                    sellView
+                    sellsOfInterest
                 );
             }
         }

--- a/src/web/BackgroundServices/ThirtyDaySellService.cs
+++ b/src/web/BackgroundServices/ThirtyDaySellService.cs
@@ -75,7 +75,7 @@ namespace web.BackgroundServices
 
                 foreach(var s in sellView.Sells)
                 {
-                    if (s.NumberOfDays >= 27)
+                    if (s.NumberOfDays >= 27 && s.NumberOfDays <= 31)
                     {
                         sellsOfInterest.Add(s);
                     }

--- a/src/web/BackgroundServices/ThirtyDaySellService.cs
+++ b/src/web/BackgroundServices/ThirtyDaySellService.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using core.Account;
+using core.Adapters.Emails;
+using core.Reports;
+using core.Reports.Views;
+using MediatR;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace web.BackgroundServices
+{
+    public class ThirtyDaySellService : BackgroundService
+    {
+        private IAccountStorage _accounts;
+        private ILogger<ThirtyDaySellService> _logger;
+        private IMediator _mediator;
+        private IEmailService _emails;
+
+        public ThirtyDaySellService(
+            ILogger<ThirtyDaySellService> logger,
+            IAccountStorage accounts,
+            IEmailService emails,
+            IMediator mediator)
+        {
+            _accounts = accounts;
+            _emails = emails;
+            _logger = logger;
+            _mediator = mediator;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            _logger.LogInformation("thirty day monitor");
+
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    await Loop(stoppingToken);
+                }
+                catch(Exception ex)
+                {
+                    _logger.LogError("Failed:" + ex);
+                }
+            }
+
+            _logger.LogInformation("thirty day monitor exit");
+        }
+
+        private async Task Loop(CancellationToken stoppingToken)
+        {
+            var time = DateTimeOffset.UtcNow;
+            
+            await ScanSells();
+
+            await Task.Delay(TimeSpan.FromHours(24), stoppingToken);
+        }
+
+        private async Task ScanSells()
+        {
+            var pairs = await _accounts.GetUserEmailIdPairs();
+
+            foreach(var p in pairs)
+            {
+                // 30 day crosser
+                var crossers = new List<SellView>();
+                var query = new Sells.Query(new Guid(p.id));
+
+                var sellView = await _mediator.Send(query);
+
+                foreach(var s in sellView.Sells)
+                {
+                    if (s.Date.Date == DateTime.UtcNow)
+                    {
+                        crossers.Add(s);
+                    }
+                }
+
+                await _emails.Send(
+                    recipient: p.email,
+                    Sender.NoReply,
+                    template: EmailTemplate.SellAlert,
+                    sellView
+                );
+            }
+        }
+    }
+}

--- a/src/web/ClientApp/src/app/recentsells/recentsells.component.ts
+++ b/src/web/ClientApp/src/app/recentsells/recentsells.component.ts
@@ -13,7 +13,7 @@ export class RecentSellsComponent implements OnInit {
 
   ngOnInit(): void {
     this.service.recentSells().subscribe( result => {
-      this.sells = result
+      this.sells = result.sells
     }, error => {
       console.log("failed: " + error);
 		})

--- a/src/web/ClientApp/src/app/services/stocks.service.ts
+++ b/src/web/ClientApp/src/app/services/stocks.service.ts
@@ -250,13 +250,16 @@ export class StocksService {
     return this.http.get<Chain>('/api/reports/chain')
   }
 
-  recentSells() : Observable<Sell[]> {
-    return this.http.get<Sell[]>('/api/reports/sells')
+  recentSells() : Observable<Sells> {
+    return this.http.get<Sells>('/api/reports/sells')
   }
 }
 
-export interface Sell {
+export interface Sells {
+  sells: Sell[]
+}
 
+export interface Sell {
 }
 
 export interface Chain {

--- a/src/web/Controllers/AccountController.cs
+++ b/src/web/Controllers/AccountController.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using web.Utils;
 
 namespace web.Controllers
@@ -17,10 +18,12 @@ namespace web.Controllers
     [Route("api/[controller]")]
     public class AccountController : ControllerBase
     {
+        private ILogger<AccountController> _logger;
         private IMediator _mediator;
 
-        public AccountController(IMediator mediator)
+        public AccountController(ILogger<AccountController> logger, IMediator mediator)
         {
+            _logger = logger;
             _mediator = mediator;
         }
         
@@ -88,7 +91,14 @@ namespace web.Controllers
                 this.User.Identifier(),
                 this.Request.HttpContext.Connection.RemoteIpAddress.ToString());
 
-            await _mediator.Send(cmd);
+            var result = await _mediator.Send(cmd);
+
+            if (result != "")
+            {
+                _logger.LogError("Unable to login: " + result);
+
+                return BadRequest(result);
+            }
             
             return this.Redirect("~/");
         }

--- a/src/web/Controllers/ReportsController.cs
+++ b/src/web/Controllers/ReportsController.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using core.Portfolio;
 using core.Portfolio.Output;
 using core.Reports;
+using core.Reports.Views;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -32,7 +33,7 @@ namespace web.Controllers
         }
 
         [HttpGet("sells")]
-        public Task<object> Sells()
+        public Task<SellsView> Sells()
         {
             var query = new Sells.Query(this.User.Identifier());
 

--- a/src/web/DIHelper.cs
+++ b/src/web/DIHelper.cs
@@ -16,6 +16,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using storage.redis;
 using storage.shared;
+using web.BackgroundServices;
 using web.Utils;
 
 namespace web
@@ -55,6 +56,7 @@ namespace web
             );
 
             services.AddHostedService<StockMonitorService>();
+            services.AddHostedService<ThirtyDaySellService>();
             
             StorageRegistrations(configuration, services);
         }

--- a/src/web/Utils/CookieEvents.cs
+++ b/src/web/Utils/CookieEvents.cs
@@ -24,18 +24,29 @@ namespace web.Utils
         public override async Task SigningIn(CookieSigningInContext context)
         {
             var email = context.Principal.Email();
+
+            _logger.LogInformation($"Obtained email {email}");
+            
+            var id = await _mediator.Send(new SignInViaGoogle.Command(email));
+            
+            (context.Principal.Identity as ClaimsIdentity).AddClaim(
+                new Claim(IdentityExtensions.ID_CLAIM_NAME, id.ToString())
+            );
+        }
+
+        public override async Task ValidatePrincipal(CookieValidatePrincipalContext context)
+        {
+            var email = context.Principal.Email();
+
+            _logger.LogInformation($"Obtained email {email}");
             
             var id = await _mediator.Send(new SignInViaGoogle.Command(email));
             if (id == null)
             {
-                await context.HttpContext.SignOutAsync(
-                    CookieAuthenticationDefaults.AuthenticationScheme);
-            }
-            else
-            {
-                (context.Principal.Identity as ClaimsIdentity).AddClaim(
-                    new Claim(IdentityExtensions.ID_CLAIM_NAME, id.ToString())
-                );
+                _logger.LogInformation($"Failed to validate principal {email}");
+
+                context.RejectPrincipal();
+                await context.HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
             }
         }
     }

--- a/src/web/Utils/CookieEvents.cs
+++ b/src/web/Utils/CookieEvents.cs
@@ -28,7 +28,7 @@ namespace web.Utils
             _logger.LogInformation($"Obtained email {email}");
             
             var id = await _mediator.Send(new SignInViaGoogle.Command(email));
-            
+
             (context.Principal.Identity as ClaimsIdentity).AddClaim(
                 new Claim(IdentityExtensions.ID_CLAIM_NAME, id.ToString())
             );

--- a/tests/coretests/CSVExportTests.cs
+++ b/tests/coretests/CSVExportTests.cs
@@ -14,7 +14,7 @@ namespace coretests
         {
             var stock = new OwnedStock("tsla", Guid.NewGuid());
             stock.Purchase(1, 100, DateTime.UtcNow, "some note");
-
+            
             var report = CSVExport.Generate(new[] {stock});
 
             Assert.Contains(CSVExport.STOCK_HEADER, report);

--- a/tests/coretests/Stocks/PositionInstanceTests.cs
+++ b/tests/coretests/Stocks/PositionInstanceTests.cs
@@ -21,7 +21,7 @@ namespace coretests.Stocks
         [Fact]
         public void DaysHeld()
         {
-            Assert.Equal(57, _position.DaysHeld);
+            Assert.True(Math.Abs(57 - _position.DaysHeld) <= 1);
         }
 
         [Fact]

--- a/tests/infrastructuretests/iexclienttests/IEXClientFixture.cs
+++ b/tests/infrastructuretests/iexclienttests/IEXClientFixture.cs
@@ -18,7 +18,7 @@ namespace iexclienttests
 
         public IEXClientFixture()
         {
-            Client = new IEXClient(CredsHelper.GetIEXToken(), useCache: false);
+            Client = new IEXClient(CredsHelper.GetIEXToken(), logger: null, useCache: false);
 
             var t = Client.GetOptions("AMD");
 

--- a/tests/infrastructuretests/iexclienttests/IEXSpikes.cs
+++ b/tests/infrastructuretests/iexclienttests/IEXSpikes.cs
@@ -14,7 +14,7 @@ namespace iexclienttests
         public IEXSpikes(Xunit.Abstractions.ITestOutputHelper helper)
         {
             _helper = helper;
-            _client = new IEXClient(CredsHelper.GetIEXToken());
+            _client = new IEXClient(CredsHelper.GetIEXToken(), logger: null);
         }
 
         [Fact]

--- a/tests/infrastructuretests/iexclienttests/iexclienttests.csproj
+++ b/tests/infrastructuretests/iexclienttests/iexclienttests.csproj
@@ -11,6 +11,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />

--- a/todo.txt
+++ b/todo.txt
@@ -1,1 +1,3 @@
 - ping when 30 days are about to pass
+
+- host on ECS


### PR DESCRIPTION
Add background service that will ping a user when their sell is approaching 30 days since the sell date. This could be a reminder for the seller to take a look at the stock again and see where it ended up or if it was sold for a loss, as a marker that it's safe to get back in within the wash sale rule framework.