### PR TITLE
Trading purchase changes - stop price and notes

### DIFF
--- a/src/core/Shared/CSVExport.cs
+++ b/src/core/Shared/CSVExport.cs
@@ -149,6 +149,15 @@ namespace core
                         sp.When.ToString(DATE_FORMAT)
                     };
                 
+                case StockPurchased_v2 sp:
+                    return new object[] {
+                        sp.Ticker,
+                        "buy",
+                        sp.NumberOfShares,
+                        sp.Price,
+                        sp.When.ToString(DATE_FORMAT)
+                    };
+                
                 case StockSold ss:
 
                     return new object[] {

--- a/src/core/Shared/CSVExport.cs
+++ b/src/core/Shared/CSVExport.cs
@@ -24,13 +24,13 @@ namespace core
         public const string PAST_TRADES_HEADER = "ticker,date,profit,percentage";
         public const string OWNED_STOCKS_HEADER = "ticker,shares,averagecost,invested,daysheld,category";
         public const string CRYPTOS_HEADER = "symbol,type,amount,price,date";
-        public const string TRADES_HEADER = "symbol,opened,closed,daysheld,firstbuycost,maxcost,maxshares,profit,returnpct,buys,sells";
+        public const string TRADES_HEADER = "symbol,opened,closed,daysheld,firstbuycost,cost,maxshares,profit,returnpct,buys,sells";
 
         public static string Generate(IEnumerable<Stocks.PositionInstance> trades)
         {
             var rows = trades.Select(t =>
                 new object[] { t.Ticker, t.Opened, t.Closed, t.DaysHeld,
-                t.FirstBuyCost,t.MaxCost, t.MaxNumberOfShares,
+                t.FirstBuyCost, t.Cost, t.MaxNumberOfShares,
                 t.Profit, t.ReturnPct,
                 t.NumberOfBuys, t.NumberOfSells
             });

--- a/src/core/Stocks/Events.cs
+++ b/src/core/Stocks/Events.cs
@@ -41,6 +41,39 @@ namespace core.Stocks
         public string Notes { get; }
     }
 
+    public class StockPurchased_v2 : 
+        AggregateEvent,
+        INotification,
+        IStockTransactionWithStopPrice
+    {
+        public StockPurchased_v2(
+            Guid id,
+            Guid aggregateId,
+            DateTimeOffset when,
+            Guid userId,
+            string ticker,
+            decimal numberOfShares,
+            decimal price,
+            string notes,
+            decimal? stopPrice)
+            : base(id, aggregateId, when)
+        {
+            UserId = userId;
+            Ticker = ticker;
+            NumberOfShares = numberOfShares;
+            Price = price;
+            Notes = notes;
+            StopPrice = stopPrice;
+        }
+
+        public Guid UserId { get; }
+        public string Ticker { get; }
+        public decimal NumberOfShares { get; }
+        public decimal Price { get; }
+        public string Notes { get; }
+        public decimal? StopPrice { get; }
+    }
+
     public class StockSold :
         AggregateEvent,
         INotification,

--- a/src/core/Stocks/Handlers/Buy.cs
+++ b/src/core/Stocks/Handlers/Buy.cs
@@ -40,7 +40,7 @@ namespace core.Stocks
                     stock = new OwnedStock(cmd.Ticker, cmd.UserId);
                 }
 
-                stock.Purchase(cmd.NumberOfShares, cmd.Price, cmd.Date.Value, cmd.Notes);
+                stock.Purchase(cmd.NumberOfShares, cmd.Price, cmd.Date.Value, cmd.Notes, cmd.StopPrice);
 
                 await _storage.Save(stock, cmd.UserId);
 

--- a/src/core/Stocks/Handlers/StockTransaction.cs
+++ b/src/core/Stocks/Handlers/StockTransaction.cs
@@ -15,6 +15,8 @@ namespace core.Stocks
         [Required]
         public DateTimeOffset? Date { get; set; }
 
+        public decimal? StopPrice { get; set; }
+
         public string Notes { get; set; }
     }
 }

--- a/src/core/Stocks/Handlers/StockTransactionHandler.cs
+++ b/src/core/Stocks/Handlers/StockTransactionHandler.cs
@@ -7,7 +7,8 @@ namespace core.Stocks
 {
     public class StockTransactionHandler : 
         MediatR.INotificationHandler<StockSold>,
-        MediatR.INotificationHandler<StockPurchased>
+        MediatR.INotificationHandler<StockPurchased>,
+        MediatR.INotificationHandler<StockPurchased_v2>
     {
         private IPortfolioStorage _storage;
         private IMediator _mediator;
@@ -34,6 +35,21 @@ namespace core.Stocks
         }
 
         public async Task Handle(StockPurchased e, CancellationToken cancellationToken)
+        {
+            var s = await _storage.GetStock(e.Ticker, e.UserId);
+            if (s == null)
+            {
+                return;
+            }
+
+            var when = e.When;
+            var notes = e.Notes;
+            var ticker = e.Ticker;
+
+            await CreateNote(e.UserId, when, notes, ticker);
+        }
+
+        public async Task Handle(StockPurchased_v2 e, CancellationToken cancellationToken)
         {
             var s = await _storage.GetStock(e.Ticker, e.UserId);
             if (s == null)

--- a/src/core/Stocks/OwnedStock.cs
+++ b/src/core/Stocks/OwnedStock.cs
@@ -24,11 +24,11 @@ namespace core.Stocks
             Apply(new TickerObtained(Guid.NewGuid(), Guid.NewGuid(), DateTimeOffset.UtcNow, ticker, userId));
         }
 
-        public void Purchase(decimal numberOfShares, decimal price, DateTimeOffset date, string notes = null)
+        public void Purchase(decimal numberOfShares, decimal price, DateTimeOffset date, string notes = null, decimal? stopPrice = null)
         {
             if (price <= 0)
             {
-                throw new InvalidOperationException("Price cannot be empty or zero");
+                throw new InvalidOperationException("Price cannot be negative or zero");
             }
 
             if (date == DateTime.MinValue)
@@ -37,7 +37,7 @@ namespace core.Stocks
             }
 
             Apply(
-                new StockPurchased(
+                new StockPurchased_v2(
                     Guid.NewGuid(),
                     State.Id,
                     date,
@@ -45,7 +45,8 @@ namespace core.Stocks
                     State.Ticker,
                     numberOfShares,
                     price,
-                    notes
+                    notes,
+                    stopPrice
                 )
             );
         }

--- a/src/core/Stocks/OwnedStockState.cs
+++ b/src/core/Stocks/OwnedStockState.cs
@@ -122,7 +122,7 @@ namespace core.Stocks
                     )
                 );
 
-                positionInstances[positionInstances.Count - 1].Buy(st.NumberOfShares, st.Price, st.When);
+                positionInstances[positionInstances.Count - 1].Buy(st.NumberOfShares, st.Price, st.When, st.Notes);
                 if (st is IStockTransactionWithStopPrice stWithStop)
                 {
                     positionInstances[positionInstances.Count - 1].SetStopPrice(stWithStop.StopPrice);
@@ -225,6 +225,7 @@ namespace core.Stocks
         decimal Price { get; }
         Guid Id { get; }
         DateTimeOffset When { get; }
+        string Notes { get; }
     }
 
     internal interface IStockTransactionWithStopPrice : IStockTransaction

--- a/src/core/Stocks/PositionInstance.cs
+++ b/src/core/Stocks/PositionInstance.cs
@@ -43,6 +43,7 @@ namespace core.Stocks
         public decimal? FirstBuyCost { get; private set; }
         public List<PositionTransaction> Buys { get; private set; } = new List<PositionTransaction>();
         public List<PositionTransaction> Sells { get; private set; } = new List<PositionTransaction>();
+        public decimal? StopPrice { get; private set; }
         private decimal TotalPrice { get; set; } = 0;
 
         public void Buy(decimal numberOfShares, decimal price, DateTimeOffset when)
@@ -90,6 +91,11 @@ namespace core.Stocks
             {
                 Closed = when;
             }
+        }
+
+        internal void SetStopPrice(decimal? stopPrice)
+        {
+            StopPrice = stopPrice;
         }
     }
 }

--- a/src/core/Stocks/PositionInstance.cs
+++ b/src/core/Stocks/PositionInstance.cs
@@ -43,10 +43,11 @@ namespace core.Stocks
         public decimal? FirstBuyCost { get; private set; }
         public List<PositionTransaction> Buys { get; private set; } = new List<PositionTransaction>();
         public List<PositionTransaction> Sells { get; private set; } = new List<PositionTransaction>();
+        public List<string> Notes { get; private set; } = new List<string>();
         public decimal? StopPrice { get; private set; }
         private decimal TotalPrice { get; set; } = 0;
 
-        public void Buy(decimal numberOfShares, decimal price, DateTimeOffset when)
+        public void Buy(decimal numberOfShares, decimal price, DateTimeOffset when, string notes = null)
         {
             if (NumberOfShares == 0)
             {
@@ -72,6 +73,11 @@ namespace core.Stocks
             if (FirstBuyCost == null)
             {
                 FirstBuyCost = price;
+            }
+
+            if (notes != null)
+            {
+                Notes.Add(notes);
             }
         }
 

--- a/src/core/Stocks/View/TradingEntryView.cs
+++ b/src/core/Stocks/View/TradingEntryView.cs
@@ -1,4 +1,6 @@
-﻿namespace core.Stocks.View
+﻿using System.Collections.Generic;
+
+namespace core.Stocks.View
 {
 
     public class TradingEntryView
@@ -12,6 +14,7 @@
             MaxCost         = state.CurrentPosition.MaxCost;
             Gain            = state.CurrentPosition.Profit;
             StopPrice       = state.CurrentPosition.StopPrice;
+            Notes           = state.CurrentPosition.Notes;
         }
 
         public decimal NumberOfShares { get; }
@@ -22,6 +25,7 @@
         public decimal Price { get; private set; }
         public decimal Gain { get; private set; }
         public decimal? StopPrice { get; }
+        public List<string> Notes { get; }
 
         internal void ApplyPrice(decimal currentPrice)
         {

--- a/src/core/Stocks/View/TradingEntryView.cs
+++ b/src/core/Stocks/View/TradingEntryView.cs
@@ -11,6 +11,7 @@
             MaxNumberOfShares = state.CurrentPosition.MaxNumberOfShares;
             MaxCost         = state.CurrentPosition.MaxCost;
             Gain            = state.CurrentPosition.Profit;
+            StopPrice       = state.CurrentPosition.StopPrice;
         }
 
         public decimal NumberOfShares { get; }
@@ -20,6 +21,7 @@
         public decimal MaxCost { get; }
         public decimal Price { get; private set; }
         public decimal Gain { get; private set; }
+        public decimal? StopPrice { get; }
 
         internal void ApplyPrice(decimal currentPrice)
         {

--- a/src/core/Stocks/View/TradingEntryView.cs
+++ b/src/core/Stocks/View/TradingEntryView.cs
@@ -11,26 +11,28 @@ namespace core.Stocks.View
             AverageCost     = state.AverageCost;
             Ticker          = state.Ticker;
             MaxNumberOfShares = state.CurrentPosition.MaxNumberOfShares;
-            MaxCost         = state.CurrentPosition.MaxCost;
             Gain            = state.CurrentPosition.Profit;
             StopPrice       = state.CurrentPosition.StopPrice;
             Notes           = state.CurrentPosition.Notes;
+            RiskedPct       = state.CurrentPosition.RiskedPct;
         }
 
         public decimal NumberOfShares { get; }
         public decimal AverageCost { get; }
         public string Ticker { get; }
         public decimal MaxNumberOfShares { get; }
-        public decimal MaxCost { get; }
         public decimal Price { get; private set; }
         public decimal Gain { get; private set; }
         public decimal? StopPrice { get; }
         public List<string> Notes { get; }
+        public decimal RiskedPct { get; }
 
         internal void ApplyPrice(decimal currentPrice)
         {
             Price = currentPrice;
             Gain = (Price - AverageCost) / AverageCost;
         }
+
+        public decimal RR => (Price - AverageCost) / AverageCost / RiskedPct;
     }
 }

--- a/src/core/Stocks/View/TradingPerformanceContainerView.cs
+++ b/src/core/Stocks/View/TradingPerformanceContainerView.cs
@@ -27,6 +27,7 @@ namespace core.Stocks.View
             var rrAmount = new DataPointContainer<decimal>("RR $");
             var maxWin = new DataPointContainer<decimal>("Max Win $");
             var maxLoss = new DataPointContainer<decimal>("Max Loss $");
+            var rrSum = new DataPointContainer<decimal>("RR Sum");
 
             closedTransactions.Reverse();
 
@@ -44,6 +45,7 @@ namespace core.Stocks.View
                 rrAmount.Add(window[0].Closed.Value, perfView.AvgWinAmount / perfView.AvgLossAmount);
                 maxWin.Add(window[0].Closed.Value, perfView.MaxWinAmount);
                 maxLoss.Add(window[0].Closed.Value, perfView.MaxLossAmount);
+                rrSum.Add(window[0].Closed.Value, perfView.rrSum);
 
                 if (i + 20 >= closedTransactions.Length)
                     break;
@@ -57,6 +59,7 @@ namespace core.Stocks.View
             Trends.Add(avgLossAmount);
             Trends.Add(rrPct);
             Trends.Add(rrAmount);
+            Trends.Add(rrSum);
             Trends.Add(maxWin);
             Trends.Add(maxLoss);
 

--- a/src/core/Stocks/View/TradingPerformanceView.cs
+++ b/src/core/Stocks/View/TradingPerformanceView.cs
@@ -29,12 +29,14 @@ namespace core.Stocks
             var totalDaysHeld = 0;
             var totalCost = 0m;
             var totalProfit = 0m;
+            var rrSum = 0m;
             
             foreach(var e in closedPositions)
             {
                 totalDaysHeld += e.DaysHeld;
                 totalProfit += e.Profit;
                 totalCost += e.Cost;
+                rrSum += e.RR;
 
                 if (e.Profit >= 0)
                 {
@@ -73,6 +75,7 @@ namespace core.Stocks
                 LossAvgReturnPct = totalLossReturnPct > 0 ? totalLossReturnPct / losses : 0,
                 Losses = losses,
                 MaxWinAmount = maxWinAmount,
+                rrSum = rrSum,
                 Total = total,
                 WinAvgDaysHeld = wins > 0 ? totalWinDaysHeld / wins : 0,
                 WinAvgReturnPct = totalWinReturnPct > 0 ? totalWinReturnPct / wins : 0,
@@ -99,5 +102,6 @@ namespace core.Stocks
         public decimal EV { get; set; }
         public decimal AvgReturnPct { get; set; }
         public double AvgDaysHeld { get; set; }
+        public decimal rrSum { get; set; }
     }
 }

--- a/src/web/ClientApp/angular.json
+++ b/src/web/ClientApp/angular.json
@@ -24,6 +24,7 @@
             ],
             "styles": [
               "node_modules/bootstrap/dist/css/bootstrap.min.css",
+              "node_modules/bootstrap-icons/font/bootstrap-icons.css",
               "src/styles.css",
               "node_modules/@fortawesome/fontawesome-free/css/all.css"
             ],

--- a/src/web/ClientApp/package-lock.json
+++ b/src/web/ClientApp/package-lock.json
@@ -18,6 +18,7 @@
         "@angular/platform-browser-dynamic": "^14.1.0",
         "@angular/router": "^14.1.0",
         "bootstrap": "^5.1.3",
+        "bootstrap-icons": "^1.9.1",
         "c": "^1.1.1",
         "chart.js": "^3.6.0",
         "chartjs-plugin-annotation": "^1.4.0",
@@ -3807,6 +3808,11 @@
       "peerDependencies": {
         "@popperjs/core": "^2.10.2"
       }
+    },
+    "node_modules/bootstrap-icons": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.9.1.tgz",
+      "integrity": "sha512-d4ZkO30MIkAhQ2nNRJqKXJVEQorALGbLWTuRxyCTJF96lRIV6imcgMehWGJUiJMJhglN0o2tqLIeDnMdiQEE9g=="
     },
     "node_modules/brace-expansion": {
       "version": "2.0.1",
@@ -16471,6 +16477,11 @@
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.1.3.tgz",
       "integrity": "sha512-fcQztozJ8jToQWXxVuEyXWW+dSo8AiXWKwiSSrKWsRB/Qt+Ewwza+JWoLKiTuQLaEPhdNAJ7+Dosc9DOIqNy7Q==",
       "requires": {}
+    },
+    "bootstrap-icons": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.9.1.tgz",
+      "integrity": "sha512-d4ZkO30MIkAhQ2nNRJqKXJVEQorALGbLWTuRxyCTJF96lRIV6imcgMehWGJUiJMJhglN0o2tqLIeDnMdiQEE9g=="
     },
     "brace-expansion": {
       "version": "2.0.1",

--- a/src/web/ClientApp/package.json
+++ b/src/web/ClientApp/package.json
@@ -21,6 +21,7 @@
     "@angular/platform-browser-dynamic": "^14.1.0",
     "@angular/router": "^14.1.0",
     "bootstrap": "^5.1.3",
+    "bootstrap-icons": "^1.9.1",
     "c": "^1.1.1",
     "chart.js": "^3.6.0",
     "chartjs-plugin-annotation": "^1.4.0",

--- a/src/web/ClientApp/src/app/services/stocks.service.ts
+++ b/src/web/ClientApp/src/app/services/stocks.service.ts
@@ -560,8 +560,9 @@ export interface StockTradingPosition {
   closed: string,
   returnPct: number,
   buys: PositionTransaction[]
-  sells: PositionTransaction[],
+  sells: PositionTransaction[]
   stopPrice: number | null
+  notes: string[] | null
 }
 
 export class OptionDefinition {

--- a/src/web/ClientApp/src/app/services/stocks.service.ts
+++ b/src/web/ClientApp/src/app/services/stocks.service.ts
@@ -563,6 +563,7 @@ export interface StockTradingPosition {
   sells: PositionTransaction[]
   stopPrice: number | null
   notes: string[] | null
+  rr: number | null
 }
 
 export class OptionDefinition {

--- a/src/web/ClientApp/src/app/services/stocks.service.ts
+++ b/src/web/ClientApp/src/app/services/stocks.service.ts
@@ -560,7 +560,8 @@ export interface StockTradingPosition {
   closed: string,
   returnPct: number,
   buys: PositionTransaction[]
-  sells: PositionTransaction[]
+  sells: PositionTransaction[],
+  stopPrice: number | null
 }
 
 export class OptionDefinition {
@@ -653,6 +654,7 @@ export class stocktransactioncommand {
   price: number
   date: string
   notes: string
+  stopPrice: number | null
 }
 
 export class brokerageordercommand {

--- a/src/web/ClientApp/src/app/services/stocks.service.ts
+++ b/src/web/ClientApp/src/app/services/stocks.service.ts
@@ -509,6 +509,7 @@ export interface StockTradingPerformance {
   lossAvgDaysHeld: number,
   ev: number,
   avgReturnPct: number,
+  rrSum: number,
 }
 
 export interface DataPoint {

--- a/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-newposition.component.html
+++ b/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-newposition.component.html
@@ -64,6 +64,10 @@
       </div>
     </div>
     <div class="row mt-2" *ngIf="prices">
+      <div class="col">
+        <textarea class="form-control" rows="5" [(ngModel)]="notes" placeholder="Notes..."></textarea>
+      </div>
+    <div class="row mt-2" *ngIf="prices">
       <div class="col" >
         <button class="btn btn-primary w-100" (click)="record()">Record</button>
       </div>

--- a/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-newposition.component.ts
+++ b/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-newposition.component.ts
@@ -160,6 +160,7 @@ export class StockTradingNewPositionComponent implements OnChanges {
     cmd.ticker = this.ticker
     cmd.numberOfShares = this.stocksToBuy
     cmd.price = this.costToBuy
+    cmd.stopPrice = this.stopPrice
     cmd.date = new Date().toISOString()
 
     this.stockService.purchase(cmd).subscribe(

--- a/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-newposition.component.ts
+++ b/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-newposition.component.ts
@@ -39,6 +39,7 @@ export class StockTradingNewPositionComponent implements OnChanges {
   costToBuy: number | null = null
   stocksToBuy : number | null = null
   stopPrice: number | null = null
+  notes: string | null = null
   exitPrice: number | null = null
   potentialProfit: number | null = null
   potentialLoss: number | null = null
@@ -161,6 +162,7 @@ export class StockTradingNewPositionComponent implements OnChanges {
     cmd.numberOfShares = this.stocksToBuy
     cmd.price = this.costToBuy
     cmd.stopPrice = this.stopPrice
+    cmd.notes = this.notes
     cmd.date = new Date().toISOString()
 
     this.stockService.purchase(cmd).subscribe(

--- a/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-past.component.html
+++ b/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-past.component.html
@@ -6,6 +6,7 @@
       <th width="100"></th>
       <th>Stock</th>
       <th>Date</th>
+      <th>R:R</th>
       <th>Profit/Loss</th>
       <th>Profit/Loss %</th>
       <th>Days Held</th>
@@ -16,6 +17,7 @@
       <td>{{i + 1}}</td>
       <td><a [routerLink]="[ '/stocks', p.ticker ]">{{p.ticker}}</a></td>
       <td>{{p.closed | date}}</td>
+      <td>{{p.rr | number:'1.0-2' }}</td>
       <td>{{p.profit | currency}}</td>
       <td>
         <span *ngIf="p.profit >= 0" class="badge bg-success me-1">win</span>

--- a/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-performance.component.html
+++ b/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-performance.component.html
@@ -29,7 +29,7 @@
       <div class="col"><div class="stat-label">Expected Value</div><div>{{performance.ev | currency}}</div></div>
       <div class="col"><div class="stat-label">Win/Loss $</div><div>{{performance.avgWinAmount / performance.avgLossAmount | number:'1.0-2'}}</div></div>
       <div class="col"><div class="stat-label">Win/Loss %</div><div>{{performance.winAvgReturnPct / performance.lossAvgReturnPct | number:'1.0-2'}}</div></div>
-      <div class="col"></div>
+      <div class="col"><div class="stat-label">R/R sum</div><div>{{performance.rrSum | number:'1.0-2'}}</div></div>
       <div class="col"></div>
     </div>  
   </div>

--- a/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-positions.component.html
+++ b/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-positions.component.html
@@ -20,8 +20,8 @@
       <div class="container">
         <div class="row">
           <div class="col">
-            <span class="badge" [ngClass]="p.price > stopNumber(p) ? 'bg-success' : 'bg-primary'">stop</span>
-            {{ stopNumber(p) | currency }}
+            <span class="badge" [ngClass]="p.price > stopPrice(p) ? 'bg-success' : 'bg-primary'">stop</span>
+            {{ stopPrice(p) | currency }}
           </div>
           <div class="col text-center">
             <span class="badge" [ngClass]="p.price > p.averageCost ? 'bg-success' : 'bg-primary'">cost</span>
@@ -48,7 +48,7 @@
           </div>
           <div class="col text-center">
             <span class="badge bg-secondary">portion</span>
-            {{ p.maxNumberOfShares / 3 | number : '1.0-2' }}
+            {{ tradingPortion(p) | number : '1.0-0' }}
           </div>
           <div class="col text-end">
           </div>

--- a/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-positions.component.html
+++ b/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-positions.component.html
@@ -51,7 +51,15 @@
             {{ tradingPortion(p) | number : '1.0-0' }}
           </div>
           <div class="col text-end">
+            <!-- note icon if position has notes -->
+            <button (click)="noteRow.className = (noteRow.className == '' ? 'visually-hidden' : '')" type="button" class="btn btn-secondary btn-sm" *ngIf="p.notes.length > 0">
+              <i class="bi bi-sticky-fill"></i>
+            </button>
           </div>
+        </div>
+
+        <div class="row" #noteRow class="visually-hidden">
+          {{ p.notes }}
         </div>
       </div>
 

--- a/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-positions.component.html
+++ b/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-positions.component.html
@@ -6,6 +6,11 @@
           <div class="col">
             <a [routerLink]="[ '/stocks', p.ticker ]" class="position-ticker">{{p.ticker}}</a>
             <span class="position-price">{{p.price | currency}}</span>
+            <i
+              (click)="noteRow.className = (noteRow.className == '' ? 'visually-hidden' : '')"
+              *ngIf="p.notes.length > 0"
+              class="bi bi-sticky-fill ms-2"
+              style="color: orange"></i>
           </div>
           <div class="col-2 text-center">
           </div>
@@ -51,15 +56,15 @@
             {{ tradingPortion(p) | number : '1.0-0' }}
           </div>
           <div class="col text-end">
-            <!-- note icon if position has notes -->
-            <button (click)="noteRow.className = (noteRow.className == '' ? 'visually-hidden' : '')" type="button" class="btn btn-secondary btn-sm" *ngIf="p.notes.length > 0">
-              <i class="bi bi-sticky-fill"></i>
-            </button>
           </div>
         </div>
 
         <div class="row" #noteRow class="visually-hidden">
-          {{ p.notes }}
+          <div class="col">
+            <div *ngFor="let note of p.notes">
+              {{ note }}
+            </div>
+          </div>
         </div>
       </div>
 

--- a/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-positions.component.html
+++ b/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-positions.component.html
@@ -10,7 +10,7 @@
           <div class="col-2 text-center">
           </div>
           <div class="col">
-            <span class="position-gain float-end">{{ rr(p) | number:'1.0-2' }}</span>
+            <span class="position-gain float-end">{{ p.rr | number:'1.0-2' }}</span>
           </div>
         </div>  
       </div>

--- a/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-positions.component.ts
+++ b/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-positions.component.ts
@@ -19,13 +19,6 @@ export class StockTradingPositionComponent {
     @Input()
     rrTarget: number
 
-    rr(p:StockTradingPosition) {
-        var currentReturn = p.price - p.averageCost
-        var risk = p.averageCost - this.stopPrice(p)
-
-        return currentReturn / risk
-    }
-
     stopPrice(p:StockTradingPosition) {
         if (p.stopPrice) {
             return p.stopPrice

--- a/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-positions.component.ts
+++ b/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-positions.component.ts
@@ -23,7 +23,10 @@ export class StockTradingPositionComponent {
         return (p.price - p.averageCost) / p.averageCost / this.stopLoss
     }
 
-    stopNumber(p:StockTradingPosition) {
+    stopPrice(p:StockTradingPosition) {
+        if (p.stopPrice) {
+            return p.stopPrice
+        }
         return p.averageCost - p.averageCost * this.stopLoss
     }
 
@@ -41,6 +44,10 @@ export class StockTradingPositionComponent {
 
     positionSize(p:StockTradingPosition) {
         return p.maxNumberOfShares * p.averageCost
+    }
+
+    tradingPortion(p:StockTradingPosition) {
+        return Math.floor(p.maxNumberOfShares / 3)
     }
 }
 

--- a/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-positions.component.ts
+++ b/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-positions.component.ts
@@ -20,7 +20,10 @@ export class StockTradingPositionComponent {
     rrTarget: number
 
     rr(p:StockTradingPosition) {
-        return (p.price - p.averageCost) / p.averageCost / this.stopLoss
+        var currentReturn = p.price - p.averageCost
+        var risk = p.averageCost - this.stopPrice(p)
+
+        return currentReturn / risk
     }
 
     stopPrice(p:StockTradingPosition) {

--- a/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-review.component.html
+++ b/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-review.component.html
@@ -27,7 +27,7 @@
       <!-- generate span for each sell showing the price and when it was executed -->
       <div class="col text-end">
         <h4>Sells [{{currentPosition.sells.length}}]</h4>
-        <span class="badge bg-danger me-1" *ngFor="let sell of currentPosition.sells">{{sell.price | currency}} on {{sell.when | date: 'MM/dd/yyyy'}}</span>
+        <span class="badge bg-success me-1" *ngFor="let sell of currentPosition.sells">{{sell.price | currency}} on {{sell.when | date: 'MM/dd/yyyy'}}</span>
       </div>
     </div>
     <div class="row mt-2">

--- a/src/web/ClientApp/src/app/summary/summary.component.html
+++ b/src/web/ClientApp/src/app/summary/summary.component.html
@@ -23,6 +23,7 @@
       <tr>
         <th>Symbol</th>
         <th>P/L</th>
+        <th>R:R</th>
         <th>Buys</th>
         <th>Sells</th>
         <th>Grade</th>
@@ -32,13 +33,19 @@
       <tr *ngFor="let p of result.closedPositions">
         <td width="140"><a [routerLink]="[ '/stocks', p.ticker ]">{{p.ticker}}</a></td>
         <td width="140">{{p.profit | currency}}</td>
+        <td width="140">{{p.rr | number:'1.0-2'}}</td>
         <td width="140">
           <div class="badge bg-success me-1" *ngFor="let buy of p.buys">{{buy.price | currency}} on {{buy.when | date: 'MM/dd/yyyy'}}</div>
         </td>
         <td width="140">
           <div class="badge bg-danger me-1" *ngFor="let sell of p.sells">{{sell.price | currency}} on {{sell.when | date: 'MM/dd/yyyy'}}</div>
         </td>
-        <td>commentary</td>
+        <td>
+          <ul class="list-unstyled" *ngIf="p.notes.length > 0">
+            <li *ngFor="let note of p.notes">{{note}}</li>
+          </ul>
+          <span *ngIf="p.notes.length == 0"> no notes </span>
+        </td>
       </tr>
       <tr *ngIf="result.closedPositions.length == 0">
         <td colspan="4">No stock positions closed</td>

--- a/tests/coretests/Stocks/PositionInstanceTests.cs
+++ b/tests/coretests/Stocks/PositionInstanceTests.cs
@@ -19,6 +19,18 @@ namespace coretests.Stocks
         }
 
         [Fact]
+        public void RR_Accurate() => Assert.Equal(3.69m, _position.RR, 2);
+
+        [Fact]
+        public void RiskedPct_Accurate() => Assert.Equal(0.05m, _position.RiskedPct);
+
+        [Fact]
+        public void RiskedAmount_Accurate() => Assert.Equal(32.5m, _position.RiskedAmount);
+
+        [Fact]
+        public void AverageCost_Accurate() => Assert.Equal(32.5m, _position.AveragePrice);
+
+        [Fact]
         public void DaysHeld()
         {
             Assert.True(Math.Abs(57 - _position.DaysHeld) <= 1);

--- a/tests/coretests/Stocks/PositionInstanceWithExplicitStopPriceTests.cs
+++ b/tests/coretests/Stocks/PositionInstanceWithExplicitStopPriceTests.cs
@@ -1,0 +1,31 @@
+using System;
+using core.Stocks;
+using Xunit;
+
+namespace coretests.Stocks
+{
+    public class PositionInstanceWithExplicitStopPriceTests
+    {
+        private PositionInstance _position;
+
+        public PositionInstanceWithExplicitStopPriceTests()
+        {
+            _position = new PositionInstance("TSLA");
+
+            _position.Buy(numberOfShares: 10, price: 30, when: DateTime.Parse("2020-01-23"));
+            _position.Buy(numberOfShares: 10, price: 35, when: DateTime.Parse("2020-01-25"));
+            _position.Sell(amount: 10, price: 40, when: DateTime.Parse("2020-02-25"));
+            _position.Sell(amount: 10, price: 37, when: DateTime.Parse("2020-03-21"));
+            _position.SetStopPrice(20);
+        }
+
+        [Fact]
+        public void RR_Accurate() => Assert.Equal(0.48m, _position.RR);
+
+        [Fact]
+        public void RiskedPct_Accurate() => Assert.Equal(0.38m, _position.RiskedPct, 2);
+
+        [Fact]
+        public void RiskedAmount_Accurate() => Assert.Equal(250m, _position.RiskedAmount, 1);
+    }
+}

--- a/tests/storagetests/postgres/PostgresPortfolioStorageTests.cs
+++ b/tests/storagetests/postgres/PostgresPortfolioStorageTests.cs
@@ -22,14 +22,6 @@ namespace storagetests.postgres
             _cnn = CredsHelper.GetDbCreds();
         }
 
-        
-
-        [Fact]
-        public async Task EndToEnd()
-        {
-            // use this test to spike up tests that need db access
-        }
-
         protected override IPortfolioStorage CreateStorage() =>
             new PortfolioStorage(
                 new PostgresAggregateStorage(new Fakes.FakeMediator(), _cnn),


### PR DESCRIPTION
Now the stop price is explicitly recorded for the trading position, and that can be used to calculate R:R versus using a fixed global stop loss % amount.

Also, exposing notes section when buying where I can jot what is my thinking around the purchase of the stock.

The notes are now shown in the trading UI so that you can refer to them when things are not going well :) 