### PR TITLE
Trading strategy end to end v1

### DIFF
--- a/src/core/Portfolio/Handlers/SimulateTrade.cs
+++ b/src/core/Portfolio/Handlers/SimulateTrade.cs
@@ -51,7 +51,7 @@ namespace core.Portfolio
                 var stock = await _storage.GetStock(ticker: request.Ticker, userId: request.UserId);
                 if (stock == null)
                 {
-                    throw new Exception("Stock not found");
+                    throw new Exception($"Stock {request.Ticker} not found");
                 }
 
                 var position = stock.State.ClosedPositions[request.PositionId];

--- a/src/core/Portfolio/Handlers/SimulateTrade.cs
+++ b/src/core/Portfolio/Handlers/SimulateTrade.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using core.Account;
+using core.Shared;
+using core.Shared.Adapters.Brokerage;
+using core.Stocks;
+using core.Stocks.Services.Trading;
+
+namespace core.Portfolio
+{
+    public class SimulateTrade
+    {
+        public class Command : RequestWithUserId<PositionInstance>
+        {
+            public Command(int positionId, string strategyName, string ticker, Guid userId)
+            {
+                PositionId = positionId;
+                StrategyName = strategyName;
+                Ticker = ticker;
+                UserId = userId;
+            }
+
+            public int PositionId { get; }
+            public string StrategyName { get; }
+            public string Ticker { get; }
+        }
+
+        public class Handler : HandlerWithStorage<Command, PositionInstance>
+        {
+            private IAccountStorage _accounts;
+            private IBrokerage _brokerage;
+            
+            public Handler(
+                IAccountStorage accounts,
+                IBrokerage brokerage,
+                IPortfolioStorage storage) : base(storage)
+            {
+                _accounts = accounts;
+                _brokerage = brokerage;
+            }
+
+            public override async Task<PositionInstance> Handle(Command request, CancellationToken cancellationToken)
+            {
+                var user = await _accounts.GetUser(request.UserId);
+                if (user == null)
+                {
+                    throw new Exception("User not found");
+                }
+
+                var stock = await _storage.GetStock(ticker: request.Ticker, userId: request.UserId);
+                if (stock == null)
+                {
+                    throw new Exception("Stock not found");
+                }
+
+                var position = stock.State.ClosedPositions[request.PositionId];
+                if (position.FirstStop == null)
+                {
+                    throw new Exception("Position has no stop");
+                }
+                
+                var runner = new TradingStrategyRunner(_brokerage);
+                var strategy = TradingStrategyFactory.Create(request.StrategyName);
+
+                return await runner.RunAsync(
+                    user.State,
+                    numberOfShares: position.FirstBuyNumberOfShares.Value,
+                    price: position.FirstBuyCost.Value,
+                    position.FirstStop.Value,
+                    request.Ticker,
+                    position.Opened.Value,
+                    strategy
+                );
+            }
+        }
+    }
+}

--- a/src/core/Stocks/OwnedStockState.cs
+++ b/src/core/Stocks/OwnedStockState.cs
@@ -54,7 +54,7 @@ namespace core.Stocks
 
             if (OpenPosition == null)
             {
-                OpenPosition = new PositionInstance(purchased.Ticker);
+                OpenPosition = new PositionInstance(ClosedPositions.Count, purchased.Ticker);
             }
 
             OpenPosition.Buy(numberOfShares: purchased.NumberOfShares, price: purchased.Price, transactionId: purchased.Id, when: purchased.When, notes: purchased.Notes);

--- a/src/core/Stocks/PositionInstance.cs
+++ b/src/core/Stocks/PositionInstance.cs
@@ -11,8 +11,9 @@ namespace core.Stocks
     // to the time when the last share is sold.
     public class PositionInstance
     {
-        public PositionInstance(string ticker)
+        public PositionInstance(int positionId, string ticker)
         {
+            PositionId = positionId;
             Ticker = ticker;
             Category = StockCategory.ShortTerm;
         }
@@ -41,6 +42,8 @@ namespace core.Stocks
         public decimal? UnrealizedRR { get; private set; } = null;
         public decimal? PercentToStop { get; private set; } = null;
         public bool IsClosed => Closed != null;
+
+        public int PositionId { get; }
         public string Ticker { get; }
         public DateTimeOffset? Closed { get; private set; }
         public decimal? FirstBuyCost { get; private set; }

--- a/src/core/Stocks/Services/Trading/ITradingStrategy.cs
+++ b/src/core/Stocks/Services/Trading/ITradingStrategy.cs
@@ -65,6 +65,7 @@ namespace core.Stocks.Services.Trading
                 if (!r2SellHappened && bar.High > position.GetRRLevel(1))
                 {
                     position.Sell(sellPortion, position.GetRRLevel(1).Value, Guid.NewGuid(), bar.Date);
+                    position.SetStopPrice(position.GetRRLevel(0).Value, bar.Date);
                     r2SellHappened = true;
                 }
 

--- a/src/core/Stocks/Services/Trading/ITradingStrategy.cs
+++ b/src/core/Stocks/Services/Trading/ITradingStrategy.cs
@@ -27,8 +27,9 @@ namespace core.Stocks.Services.Trading
 
     public class TradingStrategyFactory
     {
-        public static ITradingStrategy Create()
+        public static ITradingStrategy Create(string name)
         {
+            // TODO: use name to look up strategy
             return new TradingStrategy("1/3 on each RR level", OneThirdOnEachRRLevel.Run);
         }
     }
@@ -41,7 +42,7 @@ namespace core.Stocks.Services.Trading
             {
                 throw new InvalidOperationException("Stop price is not set");
             }
-            
+
             bool r1SellHappened = false, r2SellHappened = false;
             var sellPortion = (int)position.NumberOfShares / 3;
 

--- a/src/core/Stocks/Services/Trading/TradingStrategyRunner.cs
+++ b/src/core/Stocks/Services/Trading/TradingStrategyRunner.cs
@@ -23,7 +23,7 @@ namespace core.Stocks.Services.Trading
             DateTimeOffset when,
             ITradingStrategy strategy)
         {
-            var positionInstance = new PositionInstance(ticker);
+            var positionInstance = new PositionInstance(0, ticker);
 
             positionInstance.Buy(numberOfShares, price, when, Guid.NewGuid());
             positionInstance.SetStopPrice(stopPrice, when);

--- a/src/core/Stocks/Services/Trading/TradingStrategyRunner.cs
+++ b/src/core/Stocks/Services/Trading/TradingStrategyRunner.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Threading.Tasks;
+using core.Account;
+using core.Shared.Adapters.Brokerage;
+
+namespace core.Stocks.Services.Trading
+{
+    public class TradingStrategyRunner
+    {
+        private IBrokerage _brokerage;
+
+        public TradingStrategyRunner(IBrokerage brokerage)
+        {
+            _brokerage = brokerage;
+        }
+
+        public async Task<PositionInstance> RunAsync(
+            UserState user,
+            decimal numberOfShares,
+            decimal price,
+            decimal stopPrice,
+            string ticker,
+            DateTimeOffset when,
+            ITradingStrategy strategy)
+        {
+            var positionInstance = new PositionInstance(ticker);
+
+            positionInstance.Buy(numberOfShares, price, when, Guid.NewGuid());
+            positionInstance.SetStopPrice(stopPrice, when);
+
+            var prices = await _brokerage.GetPriceHistory(user, ticker, Shared.Adapters.Stocks.PriceFrequency.Daily, when, when.AddDays(365));
+            if (!prices.IsOk)
+            {
+                throw new Exception("Failed to get price history");
+            }
+
+            return strategy.Run(positionInstance, prices.Success);
+        }
+    }
+}

--- a/src/web/ClientApp/src/app/services/stocks.service.ts
+++ b/src/web/ClientApp/src/app/services/stocks.service.ts
@@ -57,6 +57,12 @@ export class StocksService {
     return this.http.get<TransactionList>(`/api/portfolio/transactions?ticker=${ticker}&groupBy=${groupBy}&show=${filter}&txType=${txType}`)
   }
 
+  simulatePosition(ticker: string, positionId: number): Observable<PositionInstance> {
+    return this.http.get<PositionInstance>(
+      `/api/portfolio/${ticker}/positions/${positionId}/simulate/default`
+    )
+  }
+
   smsOff(): Observable<any> {
     return this.http.post<any>('/api/alerts/sms/off', {})
   }
@@ -502,7 +508,7 @@ export class OwnedOption {
 }
 
 export interface PriceBar {
-  date: string
+  dateStr: string
   close: number
   open: number
   high: number
@@ -746,6 +752,7 @@ export interface PositionEvent {
 }
 
 export interface PositionInstance {
+  positionId: number,
   averageBuyCostPerShare: number,
   averageCostPerShare: number,
   averageSaleCostPerShare: number,

--- a/src/web/ClientApp/src/app/shared/stocks/stock-chart.component.ts
+++ b/src/web/ClientApp/src/app/shared/stocks/stock-chart.component.ts
@@ -135,7 +135,7 @@ export class StockChartComponent implements OnInit {
 
     this.lineChartData = data.concat(sma_data)
 
-    this.lineChartLabels = prices.prices.map(x => x.date).slice(-cutoff)
+    this.lineChartLabels = prices.prices.map(x => x.dateStr).slice(-cutoff)
 
     var minPrice = Math.min.apply(null, closes)
     this.lineChartOptions.scales.y.min = minPrice - minPrice * 0.1

--- a/src/web/ClientApp/src/app/stocks/stock-details/stock-analysis.component.ts
+++ b/src/web/ClientApp/src/app/stocks/stock-details/stock-analysis.component.ts
@@ -48,14 +48,14 @@ export class StockAnalysisComponent {
       this.gaps = report.gaps[0];
       this.upGaps = this.gaps.gaps.filter(g => g.type === 'Up').map(g => {
         return {
-          when: g.bar.date,
+          when: g.bar.dateStr,
           price: g.bar.open
         }
       })
       this.upGapsOpens = this.upGaps.map(g => g.price);
       this.downGaps = this.gaps.gaps.filter(g => g.type === 'Down').map(g => {
         return {
-          when: g.bar.date,
+          when: g.bar.dateStr,
           price: g.bar.open
         }
       })

--- a/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-review.component.html
+++ b/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-review.component.html
@@ -20,5 +20,8 @@
     <div class="row">
       <app-stock-trading-position [position]="currentPosition" [pendingOrders]="[]"></app-stock-trading-position>
     </div>
+    <div class="row" *ngIf="simulatedPosition">
+      <app-stock-trading-position [position]="simulatedPosition" [pendingOrders]="[]"></app-stock-trading-position>
+    </div>
   </div>
 </div>

--- a/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-review.component.ts
+++ b/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-review.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Input } from '@angular/core';
-import { Prices, PriceBar, StocksService, PositionInstance } from 'src/app/services/stocks.service';
+import { Prices, StocksService, PositionInstance } from 'src/app/services/stocks.service';
 
 
 @Component({
@@ -14,6 +14,7 @@ export class StockTradingReviewComponent implements OnInit {
   private _positions: PositionInstance[]
   private _index: number = 0
   currentPosition: PositionInstance
+  simulatedPosition: PositionInstance
   prices: Prices
 
   constructor (private stockService: StocksService) { }
@@ -31,6 +32,11 @@ export class StockTradingReviewComponent implements OnInit {
     this.stockService.getStockPrices(this.currentPosition.ticker, 365).subscribe(
       (r: Prices) => {
         this.prices = r
+      }
+    )
+    this.stockService.simulatePosition(this.currentPosition.ticker, this.currentPosition.positionId).subscribe(
+      (r: PositionInstance) => {
+        this.simulatedPosition = r
       }
     )
   }

--- a/src/web/Controllers/PortfolioController.cs
+++ b/src/web/Controllers/PortfolioController.cs
@@ -1,6 +1,7 @@
 using System.Threading.Tasks;
 using core.Portfolio;
 using core.Portfolio.Output;
+using core.Stocks;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -45,5 +46,15 @@ namespace web.Controllers
 
             return await _mediator.Send(cmd);
         }
+
+        [HttpGet("positions/{ticker}/{positionId}/simulate/{stategyName}")]
+        public Task<PositionInstance> Trade(
+            [FromQuery]int positionId,
+            [FromQuery]string strategyName,
+            [FromQuery]string ticker) =>
+            
+            _mediator.Send(
+                new SimulateTrade.Command(positionId, strategyName, ticker, User.Identifier())
+            );
     }
 }

--- a/src/web/Controllers/PortfolioController.cs
+++ b/src/web/Controllers/PortfolioController.cs
@@ -47,11 +47,11 @@ namespace web.Controllers
             return await _mediator.Send(cmd);
         }
 
-        [HttpGet("positions/{ticker}/{positionId}/simulate/{stategyName}")]
+        [HttpGet("{ticker}/positions/{positionId}/simulate/{stategyName}")]
         public Task<PositionInstance> Trade(
-            [FromQuery]int positionId,
-            [FromQuery]string strategyName,
-            [FromQuery]string ticker) =>
+            int positionId,
+            string strategyName,
+            string ticker) =>
             
             _mediator.Send(
                 new SimulateTrade.Command(positionId, strategyName, ticker, User.Identifier())

--- a/tests/coretests/Stocks/PositionInstanceTests.cs
+++ b/tests/coretests/Stocks/PositionInstanceTests.cs
@@ -10,7 +10,7 @@ namespace coretests.Stocks
 
         public PositionInstanceTests()
         {
-            _position = new PositionInstance("TSLA");
+            _position = new PositionInstance(0, "TSLA");
 
             _position.Buy(numberOfShares: 10, price: 30, when: DateTime.Parse("2020-01-23"), transactionId: Guid.NewGuid());
             _position.Buy(numberOfShares: 10, price: 35, when: DateTime.Parse("2020-01-25"), transactionId: Guid.NewGuid());
@@ -49,7 +49,7 @@ namespace coretests.Stocks
         [Fact]
         public void Cost()
         {
-            var position = new PositionInstance("TSLA");
+            var position = new PositionInstance(0, "TSLA");
 
             position.Buy(numberOfShares: 10, price: 30, when: DateTime.Parse("2020-01-23"), transactionId: Guid.NewGuid());
             position.Buy(numberOfShares: 10, price: 35, when: DateTime.Parse("2020-01-25"), transactionId: Guid.NewGuid());
@@ -60,7 +60,7 @@ namespace coretests.Stocks
         [Fact]
         public void SetPrice_SetsVariousMetricsThatDependOnIt()
         {
-            var position = new PositionInstance("TSLA");
+            var position = new PositionInstance(0, "TSLA");
 
             position.Buy(numberOfShares: 10, price: 30, when: DateTime.Parse("2020-01-23"), transactionId: Guid.NewGuid());
             position.Buy(numberOfShares: 10, price: 35, when: DateTime.Parse("2020-01-25"), transactionId: Guid.NewGuid());
@@ -86,7 +86,7 @@ namespace coretests.Stocks
         [Fact]
         public void PercentToStop_WithPriceButNoStop_SetToMax()
         {
-            var position = new PositionInstance("TSLA");
+            var position = new PositionInstance(0, "TSLA");
 
             position.Buy(numberOfShares: 10, price: 30, when: DateTime.Parse("2020-01-23"), transactionId: Guid.NewGuid());
 
@@ -107,7 +107,7 @@ namespace coretests.Stocks
         [Fact]
         public void RRLevels()
         {
-            var position = new PositionInstance("TSLA");
+            var position = new PositionInstance(0, "TSLA");
 
             position.Buy(numberOfShares: 10, price: 30, when: DateTime.Parse("2020-01-23"), transactionId: Guid.NewGuid());
             position.Buy(numberOfShares: 10, price: 35, when: DateTime.Parse("2020-01-25"), transactionId: Guid.NewGuid());

--- a/tests/coretests/Stocks/PositionInstanceWithExplicitStopPriceTests.cs
+++ b/tests/coretests/Stocks/PositionInstanceWithExplicitStopPriceTests.cs
@@ -10,7 +10,7 @@ namespace coretests.Stocks
 
         public PositionInstanceWithExplicitStopPriceTests()
         {
-            _position = new PositionInstance("TSLA");
+            _position = new PositionInstance(0, "TSLA");
 
             _position.Buy(numberOfShares: 10, price: 30, when: DateTime.Parse("2020-01-23"), transactionId: Guid.NewGuid());
             _position.Buy(numberOfShares: 10, price: 35, when: DateTime.Parse("2020-01-25"), transactionId: Guid.NewGuid());

--- a/tests/coretests/Stocks/Services/TradeStrategyRunnerTests.cs
+++ b/tests/coretests/Stocks/Services/TradeStrategyRunnerTests.cs
@@ -33,7 +33,7 @@ namespace coretests.Stocks.Services
                 .ReturnsAsync(new ServiceResponse<PriceBar[]>(prices.ToArray()));
 
             var runner = new TradingStrategyRunner(mock.Object);
-            var func = TradingStrategyFactory.Create();
+            var func = TradingStrategyFactory.Create("strategy");
 
             var result = await runner.RunAsync(
                 new UserState(),

--- a/tests/coretests/Stocks/Services/TradeStrategyRunnerTests.cs
+++ b/tests/coretests/Stocks/Services/TradeStrategyRunnerTests.cs
@@ -4,7 +4,7 @@ using core.Account;
 using core.Shared;
 using core.Shared.Adapters.Brokerage;
 using core.Shared.Adapters.Stocks;
-using core.Stocks.Services;
+using core.Stocks.Services.Trading;
 using Moq;
 using Xunit;
 
@@ -32,14 +32,17 @@ namespace coretests.Stocks.Services
             mock.Setup(x => x.GetPriceHistory(It.IsAny<UserState>(), It.IsAny<string>(), It.IsAny<PriceFrequency>(), It.IsAny<System.DateTimeOffset>(), It.IsAny<System.DateTimeOffset>()))
                 .ReturnsAsync(new ServiceResponse<PriceBar[]>(prices.ToArray()));
 
-            var runner = new TradeStrategyRunner(mock.Object);
+            var runner = new TradingStrategyRunner(mock.Object);
+            var func = TradingStrategyFactory.Create();
+
             var result = await runner.RunAsync(
                 new UserState(),
                 numberOfShares: 100,
                 price: 10,
                 stopPrice: 5,
                 ticker: "tsla",
-                when: System.DateTimeOffset.UtcNow);
+                when: System.DateTimeOffset.UtcNow,
+                func);
 
             Assert.True(result.IsClosed);
             Assert.Equal(1005, result.Profit);

--- a/tests/coretests/Stocks/TradingDataGenerator.cs
+++ b/tests/coretests/Stocks/TradingDataGenerator.cs
@@ -10,17 +10,17 @@ namespace coretests.Stocks
         {
             var closedPositions = new List<PositionInstance>();
 
-            var position = new PositionInstance("AMD");
+            var position = new PositionInstance(0, "AMD");
             position.Buy(1, 100m, DateTimeOffset.Now.AddDays(-1), transactionId: Guid.NewGuid());
             position.Sell(1, 110m, transactionId: Guid.NewGuid(), DateTimeOffset.Now);
             closedPositions.Add(position);
 
-            position = new PositionInstance("AMD");
+            position = new PositionInstance(1, "AMD");
             position.Buy(1, 100m, DateTimeOffset.Now.AddDays(-1), transactionId: Guid.NewGuid());
             position.Sell(1, 110m, transactionId: Guid.NewGuid(), DateTimeOffset.Now);
             closedPositions.Add(position);
 
-            position = new PositionInstance("AMD");
+            position = new PositionInstance(2, "AMD");
             position.Buy(1, 100m, DateTimeOffset.Now.AddDays(-1), transactionId: Guid.NewGuid());
             position.Sell(1, 90m, transactionId: Guid.NewGuid(), DateTimeOffset.Now);
             closedPositions.Add(position);


### PR DESCRIPTION
Introduce a functionality that simulates a trading position using a strategy. The outcome is a position instance with the usual position instance metrics.

I envision using this for the following:

- compare actual trades against simulated trades and see if there are significant discrepancies that could point to trading mistakes and biases
- compare actual trades against simulated trades and see if the "discretionary" additions a trader makes improve or hurt the performance
- improving actual trading by searching for trading strategies that return better results