### PR TITLE
Use value type to determine how to render outcome value

### DIFF
--- a/src/core/Stocks/Services/Analysis/MultipleBarPriceAnalysis.cs
+++ b/src/core/Stocks/Services/Analysis/MultipleBarPriceAnalysis.cs
@@ -38,6 +38,7 @@ namespace core.Stocks.Services.Analysis
                 MultipleBarOutcomeKeys.CurrentPrice,
                 OutcomeType.Neutral,
                 currentPrice,
+                OutcomeValueType.Currency,
                 $"Current price is {currentPrice:C2}"
             );
 
@@ -60,6 +61,7 @@ namespace core.Stocks.Services.Analysis
                 MultipleBarOutcomeKeys.LowestPrice,
                 OutcomeType.Neutral,
                 lowest.Close,
+                OutcomeValueType.Currency,
                 $"Lowest price was {lowest.Close} on {lowest.Date}"
             );
 
@@ -71,6 +73,7 @@ namespace core.Stocks.Services.Analysis
                 MultipleBarOutcomeKeys.LowestPriceDaysAgo,
                 lowestPriceDaysAgoOutcomeType,
                 lowestPriceDaysAgo,
+                OutcomeValueType.Number,
                 $"Lowest price was {lowest.Close} on {lowest.Date} which was {lowestPriceDaysAgo} days ago"
             );
 
@@ -81,6 +84,7 @@ namespace core.Stocks.Services.Analysis
                     MultipleBarOutcomeKeys.PercentAbovLow,
                     percentAboveLowOutcomeType,
                     percentAboveLow,
+                    OutcomeValueType.Percentage,
                     $"Percent above recent low: {percentAboveLow}%"
                 );
 
@@ -88,6 +92,7 @@ namespace core.Stocks.Services.Analysis
                 MultipleBarOutcomeKeys.HighestPrice,
                 OutcomeType.Neutral,
                 highest.Close,
+                OutcomeValueType.Currency,
                 $"Highest price was {highest.Close} on {highest.Date}"
             );
 
@@ -99,6 +104,7 @@ namespace core.Stocks.Services.Analysis
                 MultipleBarOutcomeKeys.HighestPriceDaysAgo,
                 highestPriceDaysAgoOutcomeType,
                 highestPriceDaysAgo,
+                OutcomeValueType.Number,
                 $"Highest price was {highest.Close} on {highest.Date} which was {highestPriceDaysAgo} days ago"
             );
 
@@ -109,6 +115,7 @@ namespace core.Stocks.Services.Analysis
                     MultipleBarOutcomeKeys.PercentBelowHigh,
                     percentBelowHighOutcomeType,
                     percentBelowHigh,
+                    OutcomeValueType.Percentage,
                     $"Percent below recent high: {percentBelowHigh}%"
                 );
 
@@ -124,6 +131,7 @@ namespace core.Stocks.Services.Analysis
                 MultipleBarOutcomeKeys.GapUps,
                 OutcomeType.Neutral,
                 gapUps,
+                OutcomeValueType.Number,
                 $"Open gap ups: {gapUps}"
             );
 
@@ -131,6 +139,7 @@ namespace core.Stocks.Services.Analysis
                 MultipleBarOutcomeKeys.GapDowns,
                 OutcomeType.Neutral,
                 gapDowns,
+                OutcomeValueType.Number,
                 $"open gap downs: {gapDowns}"
             );
 
@@ -145,6 +154,7 @@ namespace core.Stocks.Services.Analysis
                 MultipleBarOutcomeKeys.PercentChangeAverage,
                 OutcomeType.Neutral,
                 descriptor.mean,
+                OutcomeValueType.Number,
                 $"% Change Average: {descriptor.mean}"
             );
 
@@ -152,6 +162,7 @@ namespace core.Stocks.Services.Analysis
                 MultipleBarOutcomeKeys.PercentChangeStandardDeviation,
                 OutcomeType.Neutral,
                 descriptor.stdDev,
+                OutcomeValueType.Number,
                 $"% Change StD: {descriptor.stdDev}"
             );
         }
@@ -175,6 +186,7 @@ namespace core.Stocks.Services.Analysis
                     MultipleBarOutcomeKeys.AverageVolume,
                     OutcomeType.Neutral,
                     averageVolume,
+                    OutcomeValueType.Number,
                     $"Average volume over the last {interval} days is {averageVolume}"
                 );
         }
@@ -196,6 +208,7 @@ namespace core.Stocks.Services.Analysis
                         MultipleBarOutcomeKeys.SMA(sma.Interval),
                         OutcomeType.Neutral,
                         Math.Round(value ?? 0, 2),
+                        OutcomeValueType.Currency,
                         $"SMA {sma.Interval} is {value}"
                     );
             }
@@ -238,6 +251,7 @@ namespace core.Stocks.Services.Analysis
                     MultipleBarOutcomeKeys.SMASequence,
                     smaSequenceOutcomeType,
                     smaSequenceValue,
+                    OutcomeValueType.Number,
                     $"SMA sequence is {smaSequenceOutcomeType.ToString()}"
                 );
 
@@ -250,6 +264,7 @@ namespace core.Stocks.Services.Analysis
                     MultipleBarOutcomeKeys.SMA20Above50,
                     sma20Above50OutcomeType,
                     sma20Above50Diff,
+                    OutcomeValueType.Currency,
                     $"SMA 20 - SMA 50: {sma20Above50Diff}"
                 );
 
@@ -262,6 +277,7 @@ namespace core.Stocks.Services.Analysis
                     MultipleBarOutcomeKeys.SMA50Above150,
                     sma50Above150OutcomeType,
                     sma50Above150Diff,
+                    OutcomeValueType.Currency,
                     $"SMA 50 - SMA 150: {sma50Above150Diff}"
                 );
 
@@ -301,6 +317,7 @@ namespace core.Stocks.Services.Analysis
                     MultipleBarOutcomeKeys.SMA20Above50Days,
                     sma20Above50DaysOutcomeType,
                     sma20Above50DaysValue,
+                    OutcomeValueType.Number,
                     "SMA 20 has been " + (sma20Below50Days > 0 ? "below" : "above") + $" SMA 50 for {sma20Above50DaysValue} days"
                 );
         }

--- a/src/core/Stocks/Services/Analysis/PositionAnalysis.cs
+++ b/src/core/Stocks/Services/Analysis/PositionAnalysis.cs
@@ -13,6 +13,7 @@ namespace core.Stocks.Services.Analysis
                 PortfolioAnalysisKeys.Price,
                 OutcomeType.Neutral,
                 position.Price!.Value,
+                OutcomeValueType.Currency,
                 $"Price: {position.Price.Value:C2}"
             );
 
@@ -21,6 +22,7 @@ namespace core.Stocks.Services.Analysis
                 PortfolioAnalysisKeys.AverageCost,
                 OutcomeType.Neutral,
                 Math.Round(position.AverageCostPerShare, 2),
+                OutcomeValueType.Currency,
                 $"Average cost per share is {position.AverageCostPerShare:C2}");
 
             // add number of shares as outcome
@@ -28,6 +30,7 @@ namespace core.Stocks.Services.Analysis
                 PortfolioAnalysisKeys.NumberOfShares,
                 OutcomeType.Neutral,
                 position.NumberOfShares,
+                OutcomeValueType.Number,
                 $"Number of shares: {position.NumberOfShares}"
             );
 
@@ -36,6 +39,7 @@ namespace core.Stocks.Services.Analysis
                 PortfolioAnalysisKeys.GainPct,
                 position.UnrealizedGainPct >= 0 ? OutcomeType.Positive : OutcomeType.Negative,
                 (position.UnrealizedGainPct ?? 0),
+                OutcomeValueType.Percentage,
                 $"{position.UnrealizedGainPct:P}"
             );
 
@@ -50,6 +54,7 @@ namespace core.Stocks.Services.Analysis
                 PortfolioAnalysisKeys.RR,
                 rrOutcomeType,
                 Math.Round(position.RR, 2),
+                OutcomeValueType.Number,
                 $"{position.RR:N2}"
             );
             
@@ -60,6 +65,7 @@ namespace core.Stocks.Services.Analysis
                 PortfolioAnalysisKeys.StopLoss,
                 OutcomeType.Neutral,
                 stopLoss,
+                OutcomeValueType.Currency,
                 $"Stop loss is {stopLoss:C2}");
 
             var pctToStop = (position.PercentToStop ?? -1);
@@ -68,6 +74,7 @@ namespace core.Stocks.Services.Analysis
                     PortfolioAnalysisKeys.PercentToStopLoss,
                     pctToStop < 0 ? OutcomeType.Positive : OutcomeType.Negative,
                     pctToStop,
+                    OutcomeValueType.Percentage,
                     $"% difference to stop loss {stopLoss} is {pctToStop}"
                 );
 
@@ -76,6 +83,7 @@ namespace core.Stocks.Services.Analysis
                 PortfolioAnalysisKeys.RiskAmount,
                 OutcomeType.Neutral,
                 position.RiskedAmount ?? 0,
+                OutcomeValueType.Currency,
                 $"Risk amount is {position.RiskedAmount:C2}");
 
             // add last transaction age
@@ -83,6 +91,7 @@ namespace core.Stocks.Services.Analysis
                 PortfolioAnalysisKeys.DaysSinceLastTransaction,
                 OutcomeType.Neutral,
                 position.DaysSinceLastTransaction,
+                OutcomeValueType.Number,
                 $"Last transaction was {position.DaysSinceLastTransaction} days ago"
             );
             
@@ -93,6 +102,7 @@ namespace core.Stocks.Services.Analysis
                 PortfolioAnalysisKeys.R1Achieved,
                 r1Achieved ? OutcomeType.Positive : OutcomeType.Neutral,
                 r1Achieved ? 1 : 0,
+                OutcomeValueType.Boolean,
                 $"R1 achieved: {r1}"
             );
 
@@ -103,6 +113,7 @@ namespace core.Stocks.Services.Analysis
                 PortfolioAnalysisKeys.R2Achieved,
                 r2Achieved ? OutcomeType.Positive : OutcomeType.Neutral,
                 r2Achieved ? 1 : 0,
+                OutcomeValueType.Boolean,
                 $"R2 achieved: {r2}"
             );
 
@@ -113,6 +124,7 @@ namespace core.Stocks.Services.Analysis
                 PortfolioAnalysisKeys.R3Achieved,
                 r3Achieved ? OutcomeType.Positive : OutcomeType.Neutral,
                 r3Achieved ? 1 : 0,
+                OutcomeValueType.Boolean,
                 $"R3 achieved: {r3}"
             );
 
@@ -123,6 +135,7 @@ namespace core.Stocks.Services.Analysis
                 PortfolioAnalysisKeys.R4Achieved,
                 r4Achieved ? OutcomeType.Positive : OutcomeType.Neutral,
                 r4Achieved ? 1 : 0,
+                OutcomeValueType.Boolean,
                 $"R4 achieved: {r4}"
             );
         }

--- a/src/core/Stocks/Services/Analysis/SingleBarPriceAnalysis.cs
+++ b/src/core/Stocks/Services/Analysis/SingleBarPriceAnalysis.cs
@@ -43,6 +43,7 @@ namespace core.Stocks.Services.Analysis
                 SingleBarOutcomeKeys.SMA20Above50Days,
                 outcome.type,
                 outcome.value,
+                outcome.valueType,
                 outcome.message
             );
         }
@@ -59,6 +60,7 @@ namespace core.Stocks.Services.Analysis
                 SingleBarOutcomeKeys.Open,
                 OutcomeType.Neutral,
                 currentBar.Open,
+                OutcomeValueType.Currency,
                 "Open price");
 
             // return close as the neutral outcome
@@ -66,6 +68,7 @@ namespace core.Stocks.Services.Analysis
                 SingleBarOutcomeKeys.Close,
                 OutcomeType.Neutral,
                 currentBar.Close,
+                OutcomeValueType.Currency,
                 "Close price");
 
             // calculate closing range
@@ -76,6 +79,7 @@ namespace core.Stocks.Services.Analysis
                 key: SingleBarOutcomeKeys.ClosingRange,
                 type: range >= 0.80m ? OutcomeType.Positive : OutcomeType.Neutral,
                 value: range,
+                valueType: OutcomeValueType.Percentage,
                 message: $"Closing range is {range}.");
 
             // use yesterday's close as reference
@@ -89,6 +93,7 @@ namespace core.Stocks.Services.Analysis
                 key: SingleBarOutcomeKeys.PercentChange,
                 type: percentChange >= 0m ? OutcomeType.Positive : OutcomeType.Negative,
                 value: percentChange,
+                valueType: OutcomeValueType.Percentage,
                 message: $"% change from close is {percentChange}.");
 
             // true range uses the previous close as reference
@@ -111,6 +116,7 @@ namespace core.Stocks.Services.Analysis
                 key: SingleBarOutcomeKeys.GapPercentage,
                 type: gapType,
                 value: gap.gapSizePct,
+                valueType: OutcomeValueType.Percentage,
                 message: $"Gap is {gap.gapSizePct}%.");
 
             // see if the latest bar is a new high or new low
@@ -122,6 +128,7 @@ namespace core.Stocks.Services.Analysis
                 key: SingleBarOutcomeKeys.NewHigh,
                 type: newHigh ? OutcomeType.Positive : OutcomeType.Neutral,
                 value: newHigh ? 1m : 0m,
+                valueType: OutcomeValueType.Boolean,
                 message: $"New high reached");
 
             // add new low as outcome
@@ -129,6 +136,7 @@ namespace core.Stocks.Services.Analysis
                 key: SingleBarOutcomeKeys.NewLow,
                 type: newLow ? OutcomeType.Negative : OutcomeType.Neutral,
                 value: newLow ? -1m : 0m,
+                valueType: OutcomeValueType.Boolean,
                 message: $"New low reached");
 
             // generate percent change statistical data for recent days
@@ -153,6 +161,7 @@ namespace core.Stocks.Services.Analysis
                     _ => OutcomeType.Neutral
                 },
                 value: sigmaRatio,
+                valueType: OutcomeValueType.Number,
                 message: $"Sigma ratio is {sigmaRatio}.");
         }
     }
@@ -170,6 +179,7 @@ namespace core.Stocks.Services.Analysis
                 key: SingleBarOutcomeKeys.Volume,
                 type: OutcomeType.Neutral,
                 value: last.Volume,
+                valueType: OutcomeValueType.Number,
                 message: "Volume"));
 
             // calculate the average volume from the last x days
@@ -191,6 +201,7 @@ namespace core.Stocks.Services.Analysis
                 key: SingleBarOutcomeKeys.RelativeVolume,
                 type: relativeVolume >= 0.9m ? priceDirection : OutcomeType.Neutral,
                 value: relativeVolume,
+                valueType: OutcomeValueType.Number,
                 message: $"Relative volume is {relativeVolume}x the average volume over the last {volumeStats.count} days."
             ));
 

--- a/src/core/Stocks/Services/Analysis/Types.cs
+++ b/src/core/Stocks/Services/Analysis/Types.cs
@@ -4,7 +4,9 @@ namespace core.Stocks.Services.Analysis
 {
     public enum OutcomeType { Positive, Negative, Neutral };
 
-    public record AnalysisOutcome(string key, OutcomeType type, decimal value, string message);
+    public enum OutcomeValueType { Percentage, Currency, Number, Boolean };
+
+    public record AnalysisOutcome(string key, OutcomeType type, decimal value, OutcomeValueType valueType, string message);
 
     public record struct TickerOutcomes(List<AnalysisOutcome> outcomes, string ticker);
 

--- a/src/infrastructure/tdameritradeclient/TDAmeritradeClient.cs
+++ b/src/infrastructure/tdameritradeclient/TDAmeritradeClient.cs
@@ -26,6 +26,7 @@ public class TDAmeritradeClient : IBrokerage
 
     private HttpClient _httpClient;
     private readonly AsyncTimeoutPolicy _timeoutPolicy;
+    private readonly AsyncRateLimitPolicy _rateLimit = Policy.RateLimitAsync(10, TimeSpan.FromSeconds(1));
 
     public TDAmeritradeClient(ILogger<TDAmeritradeClient>? logger, string callbackUrl, string clientId)
     {
@@ -372,8 +373,6 @@ public class TDAmeritradeClient : IBrokerage
         }
     }
 
-    private AsyncRateLimitPolicy _rateLimit = Policy.RateLimitAsync(10, TimeSpan.FromSeconds(1));
-    private AsyncTimeoutPolicy _timeOutPolicy = Policy.TimeoutAsync(30);
 
     private async Task<string> CallApiWithoutSerialization(UserState user, string function, HttpMethod method, string? jsonData = null)
     {
@@ -394,7 +393,7 @@ public class TDAmeritradeClient : IBrokerage
             try
             {
                 var response = await _rateLimit.ExecuteAsync(
-                    async ct => await _timeOutPolicy.ExecuteAsync(
+                    async ct => await _timeoutPolicy.ExecuteAsync(
                         ct2 => _httpClient.SendAsync(request, ct2),
                         ct
                     ),

--- a/src/web/ClientApp/src/app/services/stocks.service.ts
+++ b/src/web/ClientApp/src/app/services/stocks.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable, of } from 'rxjs';
+import { UpdateModeEnum } from 'chart.js';
 
 export function GetErrors(err:any): string[] {
   var objToMap = err.error.errors
@@ -368,11 +369,19 @@ export interface AlertsContainer {
   recentlyTriggered: StockAlert[]
 }
 
+export enum OutcomeValueTypeEnum {
+  Percentage = 'Percentage',
+  Currency = 'Currency',
+  Number = 'Number',
+  Boolean = 'Boolean'
+}
+
 export interface StockAnalysisOutcome {
   type: string
   message: string
   key: string
   value: number
+  valueType: OutcomeValueTypeEnum
 }
 
 export interface Sells {

--- a/src/web/ClientApp/src/app/shared/reports/gaps.component.html
+++ b/src/web/ClientApp/src/app/shared/reports/gaps.component.html
@@ -24,8 +24,8 @@
                     </i>
                     {{g.bar.dateStr | date}}
                 </td>
-                <td>{{g.gapSizePct}}</td>
-                <td>{{g.percentChange}}</td>
+                <td>{{g.gapSizePct | percent}}</td>
+                <td>{{g.percentChange | percent}}</td>
                 <td>{{g.bar.open | currency}}</td>
                 <td>{{g.bar.close | currency}}</td>
                 <td>{{g.bar.volume | number }}</td>

--- a/src/web/ClientApp/src/app/shared/reports/outcomes.component.html
+++ b/src/web/ClientApp/src/app/shared/reports/outcomes.component.html
@@ -16,7 +16,9 @@
             <a href="https://www.tradingview.com/chart/kQn4rgoA/?symbol={{s.ticker}}" target="_blank">{{s.ticker}}</a>
           </td>
           <td *ngFor="let o of s.outcomes"
-            [ngClass]="{'text-end': true, 'text-success': o.type === 'Positive', 'text-danger': o.type === 'Negative'}" class="text-end">{{o.value }}</td>
+            [ngClass]="{'text-end': true, 'text-success': o.type === 'Positive', 'text-danger': o.type === 'Negative'}" class="text-end">
+            {{ getValue(o)}}
+          </td>
         </tr>
       </tbody>
     </table>

--- a/src/web/ClientApp/src/app/shared/reports/outcomes.component.ts
+++ b/src/web/ClientApp/src/app/shared/reports/outcomes.component.ts
@@ -1,12 +1,18 @@
+import { CurrencyPipe, PercentPipe } from '@angular/common';
 import { Component, Input } from '@angular/core';
-import { AnalysisOutcomeEvaluation, TickerOutcomes } from '../../services/stocks.service';
+import { AnalysisOutcomeEvaluation, OutcomeValueTypeEnum, StockAnalysisOutcome, TickerOutcomes } from '../../services/stocks.service';
 
 @Component({
   selector: 'app-outcomes',
   templateUrl: './outcomes.component.html',
-  styleUrls: ['./outcomes.component.css']
+  styleUrls: ['./outcomes.component.css'],
+  providers: [PercentPipe, CurrencyPipe]
 })
 export class OutcomesComponent {
+
+  constructor(
+    private percentPipe:PercentPipe,
+    private currencyPipe:CurrencyPipe) { }
 
   @Input()
   title: string
@@ -56,6 +62,16 @@ export class OutcomesComponent {
       var bVal = b.outcomes.find(o => o.key === column).value
 
       return aVal - bVal
+    }
+  }
+
+  getValue(o:StockAnalysisOutcome) {
+    if (o.valueType === OutcomeValueTypeEnum.Percentage) {
+      return this.percentPipe.transform(o.value)
+    } else if (o.valueType === OutcomeValueTypeEnum.Currency) {
+      return this.currencyPipe.transform(o.value)
+    } else {
+      return o.value
     }
   }
 }


### PR DESCRIPTION
Outcome values can be just a simple number, currency, percentage, or boolean. Instead of trying to format the number on the backend, return number as is and provide a hint of how it should be rendered in the UI.