### PR TITLE
Highlight evaluation

### DIFF
--- a/src/core/Stocks/Services/Analysis/SingleBarAnalysisOutcomeEvaluation.cs
+++ b/src/core/Stocks/Services/Analysis/SingleBarAnalysisOutcomeEvaluation.cs
@@ -13,6 +13,28 @@ namespace core.Stocks.Services.Analysis
 
         internal static IEnumerable<AnalysisOutcomeEvaluation> Evaluate(List<TickerOutcomes> tickerOutcomes)
         {
+            yield return new AnalysisOutcomeEvaluation(
+                "High Volume with Excellent Closing Range and High Percent Change",
+                OutcomeType.Positive,
+                SingleBarOutcomeKeys.RelativeVolume,
+                tickerOutcomes
+                    .Where(t =>
+                        t.outcomes.Any(o => o.key == SingleBarOutcomeKeys.RelativeVolume && o.value >= RelativeVolumeThresholdPositive)
+                        && t.outcomes.Any(o => o.key == SingleBarOutcomeKeys.ClosingRange && o.value >= ExcellentClosingRange)
+                        && t.outcomes.Any(o => o.key == SingleBarOutcomeKeys.SigmaRatio && o.value >= SigmaRatioThreshold)
+                    ).ToList()
+            );
+
+            yield return new AnalysisOutcomeEvaluation(
+                "Positive gap ups",
+                OutcomeType.Positive,
+                SingleBarOutcomeKeys.GapPercentage,
+                tickerOutcomes
+                    .Where(t =>
+                        t.outcomes.Any(o => o.key == SingleBarOutcomeKeys.GapPercentage && o.value > 0))
+                    .ToList()
+            );
+
             // stocks that had above average volume grouping
             yield return new AnalysisOutcomeEvaluation(
                 "Above Average Volume and High Percent Change",
@@ -32,18 +54,6 @@ namespace core.Stocks.Services.Analysis
                 tickerOutcomes
                     .Where(t =>
                         t.outcomes.Any(o => o.key == SingleBarOutcomeKeys.ClosingRange && o.value >= ExcellentClosingRange)
-                        && t.outcomes.Any(o => o.key == SingleBarOutcomeKeys.SigmaRatio && o.value >= SigmaRatioThreshold)
-                    ).ToList()
-            );
-
-            yield return new AnalysisOutcomeEvaluation(
-                "High Volume with Excellent Closing Range and High Percent Change",
-                OutcomeType.Positive,
-                SingleBarOutcomeKeys.RelativeVolume,
-                tickerOutcomes
-                    .Where(t =>
-                        t.outcomes.Any(o => o.key == SingleBarOutcomeKeys.RelativeVolume && o.value >= RelativeVolumeThresholdPositive)
-                        && t.outcomes.Any(o => o.key == SingleBarOutcomeKeys.ClosingRange && o.value >= ExcellentClosingRange)
                         && t.outcomes.Any(o => o.key == SingleBarOutcomeKeys.SigmaRatio && o.value >= SigmaRatioThreshold)
                     ).ToList()
             );
@@ -101,16 +111,6 @@ namespace core.Stocks.Services.Analysis
                 tickerOutcomes
                     .Where(t =>
                         t.outcomes.Any(o => o.key == SingleBarOutcomeKeys.SMA20Above50Days && o.value <= 0 && o.value > -5))
-                    .ToList()
-            );
-
-            yield return new AnalysisOutcomeEvaluation(
-                "Positive gap ups",
-                OutcomeType.Positive,
-                SingleBarOutcomeKeys.GapPercentage,
-                tickerOutcomes
-                    .Where(t =>
-                        t.outcomes.Any(o => o.key == SingleBarOutcomeKeys.GapPercentage && o.value > 0))
                     .ToList()
             );
 

--- a/src/core/Stocks/Services/Analysis/SingleBarAnalysisOutcomeEvaluation.cs
+++ b/src/core/Stocks/Services/Analysis/SingleBarAnalysisOutcomeEvaluation.cs
@@ -13,6 +13,18 @@ namespace core.Stocks.Services.Analysis
 
         internal static IEnumerable<AnalysisOutcomeEvaluation> Evaluate(List<TickerOutcomes> tickerOutcomes)
         {
+            if (tickerOutcomes.Any(o => o.outcomes.Any(o => o.key == SingleBarOutcomeKeys.Highlight)))
+            {
+                yield return new AnalysisOutcomeEvaluation(
+                    "Highlights",
+                    OutcomeType.Neutral,
+                    SingleBarOutcomeKeys.Highlight,
+                    tickerOutcomes
+                        .Where(t => t.outcomes.Any(o => o.key == SingleBarOutcomeKeys.Highlight && o.value == 1))
+                        .ToList()
+                );
+            }
+
             yield return new AnalysisOutcomeEvaluation(
                 "High Volume with Excellent Closing Range and High Percent Change",
                 OutcomeType.Positive,

--- a/src/core/Stocks/Services/Analysis/SingleBarPriceAnalysis.cs
+++ b/src/core/Stocks/Services/Analysis/SingleBarPriceAnalysis.cs
@@ -227,5 +227,6 @@ namespace core.Stocks.Services.Analysis
         public static string NewHigh = "NewHigh";
         public static string NewLow = "NewLow";
         public static string SigmaRatio = "SigmaRatio";
+        public static string Highlight = "Highlight";
     }
 }

--- a/src/web/ClientApp/src/app/reports/outcomes-report/outcomes-report.component.ts
+++ b/src/web/ClientApp/src/app/reports/outcomes-report/outcomes-report.component.ts
@@ -19,6 +19,12 @@ export class OutcomesReportComponent implements OnInit {
   }
   
   ngOnInit(): void {
+    var earningsParam = this.route.snapshot.queryParamMap.get("earnings");
+    var earnings:string[] = null
+    if (earningsParam) {
+      earnings = earningsParam.split(",")
+    }
+
     var tickerParam = this.route.snapshot.queryParamMap.get("tickers");
     if (tickerParam) {
       var tickers = tickerParam
@@ -32,7 +38,7 @@ export class OutcomesReportComponent implements OnInit {
         });
       
       if (tickers.length > 0) {
-        this.loadSingleBarReport(tickers);
+        this.loadSingleBarReport(tickers, earnings);
       }
 
     } else {
@@ -41,8 +47,8 @@ export class OutcomesReportComponent implements OnInit {
 
   }
   
-  private loadSingleBarReport(tickers: string[]) {
-    return this.stocksService.reportOutcomesSingleBarDaily(tickers).subscribe(report => {
+  private loadSingleBarReport(tickers: string[], earnings: string[]) {
+    return this.stocksService.reportOutcomesSingleBarDaily(tickers, "Earnings", earnings).subscribe(report => {
       this.singleBarReportDaily = report;
       this.loadAllBarsReport(tickers);
     }, error => {

--- a/src/web/ClientApp/src/app/services/stocks.service.ts
+++ b/src/web/ClientApp/src/app/services/stocks.service.ts
@@ -354,15 +354,28 @@ export class StocksService {
   }
 
   reportOutcomesAllBars(tickers:string[]) : Observable<OutcomesReport> {
-    return this.http.post<OutcomesReport>('/api/reports/outcomes?duration=allbars&includeGapAnalysis=true', tickers)
+    return this.http.post<OutcomesReport>(
+      '/api/reports/outcomes?duration=allbars&includeGapAnalysis=true', 
+      {tickers}
+    )
   }
 
-  reportOutcomesSingleBarDaily(tickers:string[]) : Observable<OutcomesReport> {
-    return this.http.post<OutcomesReport>('/api/reports/outcomes?duration=singlebar&frequency=daily', tickers)
+  reportOutcomesSingleBarDaily(
+    tickers:string[],
+    highlightTitle:string = null,
+    highlightTickers:string[] = null) : Observable<OutcomesReport> {
+    return this.http.post<OutcomesReport>(
+      '/api/reports/outcomes?duration=singlebar&frequency=daily',
+      {
+        tickers,highlightTitle,highlightTickers
+      }
+    )
   }
 
   reportOutcomesSingleBarWeekly(tickers:string[]) : Observable<OutcomesReport> {
-    return this.http.post<OutcomesReport>('/api/reports/outcomes?duration=singlebar&frequency=weekly', tickers)
+    return this.http.post<OutcomesReport>(
+      '/api/reports/outcomes?duration=singlebar&frequency=weekly', 
+      {tickers})
   }
 
   reportTickerPercentChangeDistribution(ticker:string): Observable<StockPercentChangeResponse> {

--- a/src/web/Controllers/ReportsController.cs
+++ b/src/web/Controllers/ReportsController.cs
@@ -40,11 +40,12 @@ namespace web.Controllers
 
         [HttpPost("outcomes")]
         public Task<OutcomesReportView> TickersOutcomes(
-            [FromBody]string[] tickers,
-            [FromQuery] PriceAnalysisReport.Duration duration,
-            [FromQuery] PriceFrequency frequency,
-            [FromQuery] bool includeGapAnalysis) =>
-            _mediator.Send(new PriceAnalysisReport.ForTickersQuery(duration, frequency, includeGapAnalysis, tickers, User.Identifier()));
+            [FromBody]PriceAnalysisReport.ForTickersQuery query)
+        {
+            query.WithUserId(User.Identifier());
+            
+            return _mediator.Send(query);
+        }
 
         [HttpGet("percentChangeDistribution/tickers/{ticker}")]
         public Task<PercentChangeStatisticsView> TickerPercentChangeDistribution(string ticker, [FromQuery] PriceFrequency frequency)


### PR DESCRIPTION
When we run analysis on a list of tickers, the outside caller might want to highlight a subset of tickers in the rendered page. Adding a parameter to the report generating code that accepts a list of tickers to highlight and then adds them as a separate evaluation category.