### PR TITLE
Add events/implementation for grade trading

### DIFF
--- a/src/core/Portfolio/Handlers/GradePosition.cs
+++ b/src/core/Portfolio/Handlers/GradePosition.cs
@@ -16,12 +16,12 @@ namespace core.Portfolio
         public class Command : RequestWithUserId<Unit>
         {
             [Required]
-            public TradeGrade Grade { get; }
+            public TradeGrade Grade { get; set; }
             [Required]
-            public string Ticker { get; }
+            public string Ticker { get; set; }
             [Required]
-            public int PositionId { get; }
-            public string Note { get; }
+            public int PositionId { get; set; }
+            public string Note { get; set; }
         }
 
         public class Handler : HandlerWithStorage<Command, Unit>
@@ -50,7 +50,7 @@ namespace core.Portfolio
                 stock.AssignGrade(
                     request.PositionId,
                     request.Grade,
-                    request.Note
+                    string.IsNullOrWhiteSpace(request.Note) ? null : request.Note
                 );
 
                 return new Unit();

--- a/src/core/Portfolio/Handlers/GradePosition.cs
+++ b/src/core/Portfolio/Handlers/GradePosition.cs
@@ -15,8 +15,27 @@ namespace core.Portfolio
     {
         public class Command : RequestWithUserId<Unit>
         {
+            private TradeGrade? _grade;
             [Required]
-            public TradeGrade Grade { get; set; }
+            public string Grade 
+            {
+                get 
+                { 
+                    if (_grade == null) return null;
+                    return _grade;
+                }
+                
+                set 
+                {
+                    if (string.IsNullOrWhiteSpace(value))
+                    {
+                        _grade = null;
+                        return;
+                    }
+                    _grade = new TradeGrade(value);
+                }
+            }
+
             [Required]
             public string Ticker { get; set; }
             [Required]
@@ -52,6 +71,8 @@ namespace core.Portfolio
                     request.Grade,
                     string.IsNullOrWhiteSpace(request.Note) ? null : request.Note
                 );
+
+                await _storage.Save(stock, request.UserId);
 
                 return new Unit();
             }

--- a/src/core/Portfolio/Handlers/GradePosition.cs
+++ b/src/core/Portfolio/Handlers/GradePosition.cs
@@ -1,0 +1,60 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using core.Account;
+using core.Shared;
+using core.Stocks;
+using core.Stocks.Services.Trading;
+using MediatR;
+
+namespace core.Portfolio
+{
+    public class GradePosition
+    {
+        public class Command : RequestWithUserId<Unit>
+        {
+            [Required]
+            public TradeGrade Grade { get; }
+            [Required]
+            public string Ticker { get; }
+            [Required]
+            public int PositionId { get; }
+            public string Note { get; }
+        }
+
+        public class Handler : HandlerWithStorage<Command, Unit>
+        {
+            private IAccountStorage _accounts;
+
+            public Handler(IAccountStorage accounts, IPortfolioStorage storage) : base(storage)
+            {
+                _accounts = accounts;
+            }
+
+            public override async Task<Unit> Handle(Command request, CancellationToken cancellationToken)
+            {
+                var user = await _accounts.GetUser(request.UserId);
+                if (user == null)
+                {
+                    throw new Exception("User not found");
+                }
+
+                var stock = await _storage.GetStock(request.Ticker, request.UserId);
+                if (stock == null)
+                {
+                    throw new Exception("Stock not found");
+                }
+
+                stock.AssignGrade(
+                    request.PositionId,
+                    request.Grade,
+                    request.Note
+                );
+
+                return new Unit();
+            }
+        }
+    }
+}

--- a/src/core/Shared/CSVExport.cs
+++ b/src/core/Shared/CSVExport.cs
@@ -21,7 +21,7 @@ namespace core
         private record struct OptionRecord(string ticker, string type, decimal strike, string optiontype, string expiration, decimal amount, decimal premium, string filled);
         private record struct UserRecord(string email, string first_name, string last_name);
         private record struct CryptosRecord(string symbol, string type, decimal amount, decimal price, string date);
-        private record struct TradesRecord(string symbol, string opened, string closed, decimal daysheld, decimal firstbuycost, decimal cost, decimal profit, decimal returnpct, decimal rr, decimal? riskedAmount);
+        private record struct TradesRecord(string symbol, string opened, string closed, decimal daysheld, decimal firstbuycost, decimal cost, decimal profit, decimal returnpct, decimal rr, decimal? riskedAmount, string grade, string gradeNote);
         private record struct StockListRecord(string ticker, string created, string notes);
         private record struct StockListRecordJustTicker(string ticker);
         private record struct TradingStrategyResultRecord(string strategyName, string ticker, decimal numberOfShares, decimal cost, decimal averageBuyCostPerShare, decimal averageSaleCostPerShare, string opened, string closed, decimal daysHeld, decimal profit, decimal rr, decimal returnPct);
@@ -62,9 +62,20 @@ namespace core
         public static string Generate(ICSVWriter writer, IEnumerable<Stocks.PositionInstance> trades)
         {
             var rows = trades.Select(t =>
-                new TradesRecord(t.Ticker, t.Opened?.ToString(DATE_FORMAT), t.Closed?.ToString(DATE_FORMAT), t.DaysHeld,
-                t.CompletedPositionCostPerShare, t.Cost,
-                t.Profit, t.IsClosed ? t.GainPct : t.UnrealizedGainPct.Value,t.RR, t.RiskedAmount)
+                new TradesRecord(
+                    symbol: t.Ticker,
+                    opened: t.Opened?.ToString(DATE_FORMAT),
+                    closed: t.Closed?.ToString(DATE_FORMAT),
+                    daysheld: t.DaysHeld,
+                    firstbuycost: t.CompletedPositionCostPerShare,
+                    cost: t.Cost,
+                    profit: t.Profit,
+                    returnpct: t.IsClosed ? t.GainPct : t.UnrealizedGainPct.Value,
+                    rr: t.RR,
+                    riskedAmount: t.RiskedAmount,
+                    grade: t.Grade,
+                    gradeNote: t.GradeNote
+                )
             );
 
             return writer.Generate(rows);

--- a/src/core/Shared/TradeGrade.cs
+++ b/src/core/Shared/TradeGrade.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace core.Shared
+{
+    public struct TradeGrade
+    {
+        private readonly string _grade;
+
+        public TradeGrade(string grade)
+        {
+            if (string.IsNullOrWhiteSpace(grade))
+            {
+                throw new ArgumentException(nameof(grade), "Grade cannot be blank");
+            }
+            
+            // right now we allow only A, B, C
+            // this feels like should be configurable by trader?
+            if (!grade.Equals("A", StringComparison.OrdinalIgnoreCase) &&
+                !grade.Equals("B", StringComparison.OrdinalIgnoreCase) &&
+                !grade.Equals("C", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new ArgumentException(nameof(grade), "Grade must be A, B, or C");
+            }
+
+            _grade = grade.ToUpper();
+        }
+
+        public static implicit operator string(TradeGrade g) => g._grade;
+        public static implicit operator TradeGrade(string g) => new TradeGrade(g);
+        public string Value => _grade;
+    }
+}

--- a/src/core/Stocks/Events.cs
+++ b/src/core/Stocks/Events.cs
@@ -179,4 +179,20 @@ namespace core.Stocks
         public Guid UserId { get; }
         public string Ticker { get; }
     }
+
+    public class TradeGradeAssigned : AggregateEvent, INotification
+    {
+        public TradeGradeAssigned(Guid id, Guid aggregateId, DateTimeOffset when, Guid userId, string grade, string note, int positionId) : base(id, aggregateId, when)
+        {
+            UserId = userId;
+            Grade = grade;
+            Note = note;
+            PositionId = positionId;
+        }
+
+        public Guid UserId { get; }
+        public int PositionId { get; }
+        public string Grade { get; }
+        public string Note { get; }
+    }
 }

--- a/src/core/Stocks/Handlers/ExportTrades.cs
+++ b/src/core/Stocks/Handlers/ExportTrades.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using core.Account;
-using core.Adapters.Stocks;
 using core.Shared;
 using core.Shared.Adapters.Brokerage;
 using core.Shared.Adapters.CSV;

--- a/src/core/Stocks/OwnedStock.cs
+++ b/src/core/Stocks/OwnedStock.cs
@@ -188,5 +188,36 @@ namespace core.Stocks
                     notes)
             );
         }
+
+        public void AssignGrade(int positionId, TradeGrade grade, string note)
+        {
+            var position = State.Positions.SingleOrDefault(p => p.PositionId == positionId);
+            if (position == null)
+            {
+                throw new InvalidOperationException("Unable to find position with id " + positionId);
+            }
+
+            if (!position.IsClosed)
+            {
+                throw new InvalidOperationException("Cannot assign grade to an open position");
+            }
+
+            if (position.Grade == grade && position.GradeNote == note)
+            {
+                return;
+            }
+
+            Apply(
+                new TradeGradeAssigned(
+                    Guid.NewGuid(),
+                    State.Id,
+                    DateTimeOffset.UtcNow,
+                    userId: State.UserId,
+                    grade: grade,
+                    note: note,
+                    positionId: positionId
+                )
+            );
+        }
     }
 }

--- a/src/core/Stocks/OwnedStockState.cs
+++ b/src/core/Stocks/OwnedStockState.cs
@@ -17,6 +17,8 @@ namespace core.Stocks
         public List<PositionInstance> Positions { get; } = new List<PositionInstance>();
         public PositionInstance OpenPosition { get; private set;}
 
+        private int _positionId = 0;
+
         internal void ApplyInternal(TickerObtained o)
         {
             Id = o.AggregateId;
@@ -48,14 +50,21 @@ namespace core.Stocks
             OpenPosition.SetRiskAmount(riskAmountSet.RiskAmount, riskAmountSet.When);
         }
 
+        internal void ApplyInternal(TradeGradeAssigned gradeAssigned)
+        {
+            var position = Positions.Single(x => x.PositionId == gradeAssigned.PositionId);
+            position.SetGrade(gradeAssigned.Grade, gradeAssigned.Note);
+        }
+
         internal void ApplyInternal(StockPurchased_v2 purchased)
         {
             BuyOrSell.Add(purchased);
 
             if (OpenPosition == null)
             {
-                OpenPosition = new PositionInstance(Positions.Count, purchased.Ticker);
+                OpenPosition = new PositionInstance(_positionId, purchased.Ticker);
                 Positions.Add(OpenPosition);
+                _positionId++;
             }
 
             OpenPosition.Buy(numberOfShares: purchased.NumberOfShares, price: purchased.Price, transactionId: purchased.Id, when: purchased.When, notes: purchased.Notes);

--- a/src/core/Stocks/PositionInstance.cs
+++ b/src/core/Stocks/PositionInstance.cs
@@ -83,7 +83,7 @@ namespace core.Stocks
         public decimal CompletedPositionShares = 0;
         public decimal CompletedPositionCostPerShare => CompletedPositionCost / CompletedPositionShares;
 
-        public TradeGrade? Grade { get; private set; } = null;
+        public string Grade { get; private set; } = null;
         public string GradeNote { get; private set; } = null;
         public void SetGrade(TradeGrade grade, string note = null)
         {

--- a/src/core/Stocks/PositionInstance.cs
+++ b/src/core/Stocks/PositionInstance.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using core.Shared;
 
 namespace core.Stocks
 {
@@ -81,6 +82,15 @@ namespace core.Stocks
         private decimal CompletedPositionCost = 0;
         public decimal CompletedPositionShares = 0;
         public decimal CompletedPositionCostPerShare => CompletedPositionCost / CompletedPositionShares;
+
+        public TradeGrade? Grade { get; private set; } = null;
+        public string GradeNote { get; private set; } = null;
+        public void SetGrade(TradeGrade grade, string note = null)
+        {
+            Grade = grade;
+            GradeNote = note;
+            Notes.Add(note);
+        }
 
         public void Buy(decimal numberOfShares, decimal price, DateTimeOffset when, Guid transactionId, string notes = null)
         {

--- a/src/web/ClientApp/src/app/alerts/alerts.component.html
+++ b/src/web/ClientApp/src/app/alerts/alerts.component.html
@@ -7,6 +7,9 @@
     <button class="btn btn-primary me-2" (click)="toggleVisibility(messagesSection)" *ngIf="!hideMessages">
       Toggle Messages ({{container.messages.length}})
     </button>
+    <div class="float-end text-muted" role="status">
+      last refresh: {{lastRefreshed | date:'medium'}}
+    </div>
 
     <div class="alert alert-success mt-3" role="alert" *ngIf="scheduled">
       Scheduled!

--- a/src/web/ClientApp/src/app/alerts/alerts.component.ts
+++ b/src/web/ClientApp/src/app/alerts/alerts.component.ts
@@ -15,6 +15,7 @@ export class AlertsComponent implements OnInit, AfterViewInit, OnDestroy {
   container: AlertsContainer;
   alertGroups: StockAlert[][];
   intervalId: any;
+  lastRefreshed: string;
 
   constructor(
     private stockService : StocksService,
@@ -48,7 +49,6 @@ export class AlertsComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   fetchData() {
-    console.log("fetching data")
     this.stockService.getAlerts().subscribe(container => {
       this.container = container;
 
@@ -67,6 +67,8 @@ export class AlertsComponent implements OnInit, AfterViewInit, OnDestroy {
       groups.sort((a,b) => a[0].description.localeCompare(b[0].description));
 
       this.alertGroups = groups
+      this.lastRefreshed = new Date().toLocaleString();
+      this.scheduled = false
     });
   }
 

--- a/src/web/ClientApp/src/app/services/stocks.service.ts
+++ b/src/web/ClientApp/src/app/services/stocks.service.ts
@@ -29,7 +29,7 @@ export class StocksService {
 
   simulatePosition(ticker: string, positionId: number): Observable<TradingStrategyResults> {
     return this.http.get<TradingStrategyResults>(
-      `/api/portfolio/simulate/trades/${ticker}/positions/${positionId}`
+      `/api/portfolio/${ticker}/positions/${positionId}/simulate/trades`
     )
   }
 
@@ -45,7 +45,14 @@ export class StocksService {
 
   getStrategyProfitPoints(ticker: string, positionId: number): Observable<StrategyProfitPoint[]> {
     return this.http.get<StrategyProfitPoint[]>(
-      `/api/portfolio/profitpoints/${ticker}/positions/${positionId}`
+      `/api/portfolio/${ticker}/positions/${positionId}/profitpoints`
+    )
+  }
+
+  assignGrade(ticker: string, positionId: number, grade: string, note: string): Observable<any> {
+    return this.http.post<any>(
+      `/api/portfolio/${ticker}/positions/${positionId}/grade`,
+      { grade, note }
     )
   }
 
@@ -868,8 +875,10 @@ export interface PositionInstance {
   unrealizedProfit: number,
   unrealizedRR: number,
   combinedProfit: number,
-  percentToStop: number
-  costAtRiskedBasedOnStopPrice: number
+  percentToStop: number,
+  costAtRiskedBasedOnStopPrice: number,
+  grade: string,
+  gradeNote: string
 }
 
 export interface TradingStrategyResult {

--- a/src/web/ClientApp/src/app/services/stocks.service.ts
+++ b/src/web/ClientApp/src/app/services/stocks.service.ts
@@ -52,7 +52,7 @@ export class StocksService {
   assignGrade(ticker: string, positionId: number, grade: string, note: string): Observable<any> {
     return this.http.post<any>(
       `/api/portfolio/${ticker}/positions/${positionId}/grade`,
-      { grade, note }
+      { grade, note, ticker, positionId }
     )
   }
 

--- a/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-closed-positions.component.html
+++ b/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-closed-positions.component.html
@@ -10,6 +10,7 @@
         <th>R:R</th>
         <th>Profit/Loss</th>
         <th>Profit/Loss %</th>
+        <th>Grade</th>
         <th>Days Held</th>
       </tr>
     </thead>
@@ -25,6 +26,7 @@
           <span *ngIf="p.profit < 0" class="badge bg-warning me-1">loss</span>
           {{p.gainPct | percent:'1.0-2' }}
         </td>
+        <td>{{p.grade}}</td>
         <td>{{p.daysHeld}}</td>
       </tr>
     </tbody>

--- a/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-review.component.html
+++ b/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-review.component.html
@@ -48,5 +48,20 @@
     <h5>Position Information</h5>
     <app-stock-trading-position [position]="currentPosition"></app-stock-trading-position>
   </section>
+
+  <section>
+    <div class="mb-3">
+      <label for="gradeInput" class="form-label">Grade</label>
+      <input #gradeInput type="text" class="form-control" id="gradeInput" aria-describedby="gradeHelp">
+      <div id="gradeHelp" class="form-text">Grade for trade: A, B, C</div>
+    </div>
+    <div class="mb-3">
+      <label for="notesInput" class="form-label">Notes</label>
+      <textarea #gradeNotes class="form-control" id="notesInput" rows="3"></textarea>
+    </div>
+    <div>
+      <button (click)="assignGrade(gradeInput.value, gradeNotes.value)" class="btn btn-primary">Submit Grade</button>
+    </div>
+  </section>
   
 </div>

--- a/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-review.component.html
+++ b/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-review.component.html
@@ -50,14 +50,20 @@
   </section>
 
   <section>
+    <div *ngIf="gradingError" class="alert alert-danger" role="alert">
+      {{gradingError }}
+    </div>
+    <div *ngIf="gradingSuccess" class="alert alert-success" role="alert">
+      {{gradingSuccess }}
+    </div>
     <div class="mb-3">
       <label for="gradeInput" class="form-label">Grade</label>
-      <input #gradeInput type="text" class="form-control" id="gradeInput" aria-describedby="gradeHelp">
+      <input #gradeInput value="{{currentPosition.grade}}" type="text" class="form-control" id="gradeInput" aria-describedby="gradeHelp">
       <div id="gradeHelp" class="form-text">Grade for trade: A, B, C</div>
     </div>
     <div class="mb-3">
       <label for="notesInput" class="form-label">Notes</label>
-      <textarea #gradeNotes class="form-control" id="notesInput" rows="3"></textarea>
+      <textarea #gradeNotes class="form-control" id="notesInput" rows="3">{{currentPosition.gradeNote}}</textarea>
     </div>
     <div>
       <button (click)="assignGrade(gradeInput.value, gradeNotes.value)" class="btn btn-primary">Submit Grade</button>

--- a/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-review.component.ts
+++ b/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-review.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { Prices, StocksService, PositionInstance, TradingStrategyResults, StockTradingPositions, DailyOutcomeScoresReport } from 'src/app/services/stocks.service';
+import { GetErrors } from 'src/app/services/utils';
 
 
 @Component({
@@ -103,10 +104,16 @@ export class StockTradingReviewComponent implements OnInit {
     return positionInstance.transactions.filter(t => t.type == 'sell')
   }
 
+  gradingError: string = null
+  gradingSuccess: string = null
   assignGrade(grade:string, note:string) {
     this.stockService.assignGrade(this.currentPosition.ticker, this.currentPosition.positionId, grade, note).subscribe(
-      (r: any) => {
-        console.log("grade saved")
+      (_: any) => {
+        this.gradingSuccess = "Grade assigned successfully"
+      },
+      (error) => {
+        let errors = GetErrors(error)
+        this.gradingError = errors.join(', ')
       }
     );
   }

--- a/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-review.component.ts
+++ b/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-review.component.ts
@@ -103,4 +103,12 @@ export class StockTradingReviewComponent implements OnInit {
     return positionInstance.transactions.filter(t => t.type == 'sell')
   }
 
+  assignGrade(grade:string, note:string) {
+    this.stockService.assignGrade(this.currentPosition.ticker, this.currentPosition.positionId, grade, note).subscribe(
+      (r: any) => {
+        console.log("grade saved")
+      }
+    );
+  }
+
 }

--- a/src/web/Controllers/PortfolioController.cs
+++ b/src/web/Controllers/PortfolioController.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using core.Portfolio;
 using core.Portfolio.Handlers;
 using core.Portfolio.Output;
+using core.Stocks;
 using core.Stocks.Services.Trading;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
@@ -115,7 +116,7 @@ namespace web.Controllers
                 )
             );
 
-        [HttpGet("simulate/trades/{ticker}/positions/{positionId}")]
+        [HttpGet("{ticker}/positions/{positionId}/simulate/trades")]
         public Task<TradingStrategyResults> Trade(
             int positionId,
             string ticker) =>
@@ -126,7 +127,7 @@ namespace web.Controllers
                 )
             );
 
-        [HttpGet("profitpoints/{ticker}/positions/{positionId}")]
+        [HttpGet("{ticker}/positions/{positionId}/profitpoints")]
         public Task<core.Stocks.Services.Trading.ProfitPoints.ProfitPointContainer[]> ProfitPoints(
             int positionId,
             string ticker) =>
@@ -137,7 +138,18 @@ namespace web.Controllers
                 )
             );
 
-        [HttpGet("simulate/trades/{ticker}")]
+        [HttpPost("{ticker}/positions/{positionId}/grade")]
+        public Task Grade(
+            int positionId,
+            string ticker,
+            [FromBody]GradePosition.Command command)
+        {
+            command.WithUserId(User.Identifier());
+
+            return _mediator.Send(command);
+        }
+
+        [HttpGet("{ticker}/simulate/trades")]
         public Task<TradingStrategyResults> Trade(
             string ticker,
             [FromQuery]decimal numberOfShares,

--- a/src/web/Utils/MarketHours.cs
+++ b/src/web/Utils/MarketHours.cs
@@ -36,10 +36,10 @@ namespace web.Utils
 
         public DateTimeOffset ToMarketTime(DateTimeOffset when) => ConvertToEastern(when);
 
-        public DateTimeOffset GetMarketStartOfDayTimeInUtc(DateTimeOffset when)
+        public DateTimeOffset GetMarketStartOfDayTimeInUtc(DateTimeOffset eastern)
         {
             return TimeZoneInfo.ConvertTimeToUtc(
-                when.Date.Add(StartTime),
+                eastern.Date.Add(StartTime),
                 _easternZoneId
             );
         }


### PR DESCRIPTION
Currently exposing assigning the grade on the review screen, and showing it in the past positions and past positions export screen.

A big change as part of this is how position instance IDs are assigned. ID is now maintained as an independent counter, separate from the positions array.