### PR TITLE
Pending positions

### DIFF
--- a/src/core/Portfolio/Events.cs
+++ b/src/core/Portfolio/Events.cs
@@ -76,4 +76,42 @@ namespace core.Portfolio
 
         public string Tag { get; }
     }
+
+    internal class PendingStockPositionCreated : AggregateEvent
+    {
+        public PendingStockPositionCreated(
+            Guid id,
+            Guid aggregateId,
+            DateTimeOffset when,
+            Guid userId,
+            string ticker,
+            decimal price,
+            decimal numberOfShares,
+            decimal? stopPrice,
+            string notes)
+            : base(id, aggregateId, when)
+        {
+            UserId = userId;
+            Ticker = ticker;
+            Price = price;
+            NumberOfShares = numberOfShares;
+            StopPrice = stopPrice;
+            Notes = notes;
+        }
+
+        public Guid UserId { get; }
+        public string Ticker { get; }
+        public decimal Price { get; }
+        public decimal NumberOfShares { get; }
+        public decimal? StopPrice { get; }
+        public string Notes { get; }
+    }
+
+    public class PendingStockPositionDeleted : AggregateEvent
+    {
+        public PendingStockPositionDeleted(Guid id, Guid aggregateId, DateTimeOffset when)
+            : base(id, aggregateId, when)
+        {
+        }
+    }
 }

--- a/src/core/Portfolio/Handlers/PendingStockPositionClose.cs
+++ b/src/core/Portfolio/Handlers/PendingStockPositionClose.cs
@@ -1,0 +1,55 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using core.Account;
+using core.Shared;
+using core.Shared.Adapters.Brokerage;
+using MediatR;
+
+namespace core.Portfolio.Handlers
+{
+    public class PendingStockPositionClose
+    {
+        public class Command : RequestWithUserId
+        {
+            public Command(Guid positionId, Guid userId) : base(userId)
+            {
+                PositionId = positionId;
+            }
+
+            public Guid PositionId { get; }
+        }
+
+        public class Handler : HandlerWithStorage<Command, Unit>
+        {
+            private IAccountStorage _accountStorage;
+            private IBrokerage _brokerage;
+
+            public Handler(
+                IBrokerage brokerage,
+                IAccountStorage accountStorage,
+                IPortfolioStorage storage) : base(storage)
+            {
+                _accountStorage = accountStorage;
+                _brokerage = brokerage;
+            }
+
+            public override async Task<Unit> Handle(Command request, CancellationToken cancellationToken)
+            {
+                // check if there is already a pending position for this ticker
+                var existing = await _storage.GetPendingStockPositions(request.UserId);
+                var found = existing.SingleOrDefault(x => x.State.Id == request.PositionId);
+                if (found == null)
+                {
+                    throw new Exception("Position not found");
+                }
+
+                await _storage.DeletePendingStockPosition(found, request.UserId);
+
+                return Unit.Value;
+            }
+        }
+    }
+}

--- a/src/core/Portfolio/Handlers/PendingStockPositionCreate.cs
+++ b/src/core/Portfolio/Handlers/PendingStockPositionCreate.cs
@@ -1,0 +1,49 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Threading;
+using System.Threading.Tasks;
+using core.Shared;
+
+namespace core.Portfolio.Handlers
+{
+    public class PendingStockPositionCreate
+    {
+        public class Command : RequestWithUserId<PendingStockPositionState>
+        {
+            [Required]
+            public string Notes { get; set; }
+            [Required]
+            [Range(1, int.MaxValue)]
+            public decimal NumberOfShares { get; set; }
+            [Required]
+            [Range(0.01, int.MaxValue)]
+            public decimal Price { get; set; }
+            [Range(0, int.MaxValue)]
+            public decimal? StopPrice { get; set; }
+            [Required]
+            public string Ticker { get; set; }
+        }
+
+        public class Handler : HandlerWithStorage<Command, PendingStockPositionState>
+        {
+            public Handler(IPortfolioStorage storage) : base(storage)
+            {
+            }
+
+            public override async Task<PendingStockPositionState> Handle(Command request, CancellationToken cancellationToken)
+            {
+                var pending = new PendingStockPosition(
+                    notes: request.Notes,
+                    numberOfShares: request.NumberOfShares,
+                    price: request.Price,
+                    stopPrice: request.StopPrice,
+                    ticker: request.Ticker,
+                    userId: request.UserId);
+
+                await _storage.Save(pending, request.UserId);
+
+                return pending.State;
+            }
+        }
+    }
+}

--- a/src/core/Portfolio/Handlers/PendingStockPositionsGet.cs
+++ b/src/core/Portfolio/Handlers/PendingStockPositionsGet.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using core.Shared;
+
+namespace core.Portfolio.Handlers
+{
+    public class PendingStockPositionsGet
+    {
+        public class Query : RequestWithUserId<IEnumerable<PendingStockPositionState>>
+        {
+            public Query(Guid userId) : base(userId)
+            {
+            }
+        }
+
+        public class Handler : HandlerWithStorage<Query, IEnumerable<PendingStockPositionState>>
+        {
+            public Handler(IPortfolioStorage storage) : base(storage)
+            {
+            }
+
+            public override async Task<IEnumerable<PendingStockPositionState>> Handle(Query query, CancellationToken cancellationToken)
+            {
+                var positions = await _storage.GetPendingStockPositions(query.UserId);
+
+                return positions.Select(x => x.State);
+            }
+        }
+    }
+}

--- a/src/core/Portfolio/IPortfolioStorage.cs
+++ b/src/core/Portfolio/IPortfolioStorage.cs
@@ -25,6 +25,10 @@ namespace core
         Task Save(StockList list, Guid userId);
         Task DeleteStockList(StockList list, Guid id);
 
+        Task Save(PendingStockPosition position, Guid userId);
+        Task<IEnumerable<PendingStockPosition>> GetPendingStockPositions(Guid userId);
+        Task DeletePendingStockPosition(PendingStockPosition position, Guid userId);
+
 
         Task<IEnumerable<OwnedOption>> GetOwnedOptions(Guid userId);
         Task<OwnedOption> GetOwnedOption(Guid optionId, Guid userId);

--- a/src/core/Portfolio/PendingStockPosition.cs
+++ b/src/core/Portfolio/PendingStockPosition.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using core.Shared;
+
+namespace core.Portfolio
+{
+    public class PendingStockPosition : Aggregate
+    {
+        public PendingStockPositionState State { get; } = new PendingStockPositionState();
+        public override IAggregateState AggregateState => State;
+
+        public PendingStockPosition(IEnumerable<AggregateEvent> events) : base(events)
+        {
+        }
+
+        public PendingStockPosition(
+            string notes,
+            decimal numberOfShares,
+            decimal price,
+            decimal? stopPrice,
+            Ticker ticker,
+            Guid userId)
+        {
+            if (userId == Guid.Empty)
+            {
+                throw new InvalidOperationException("Missing user id");
+            }
+
+            if (price <= 0)
+            {
+                throw new InvalidOperationException("Price cannot be negative or zero");
+            }
+
+            if (numberOfShares <= 0)
+            {
+                throw new InvalidOperationException("Number of shares cannot be negative or zero");
+            }
+
+            if (stopPrice.HasValue && stopPrice.Value < 0)
+            {
+                throw new InvalidOperationException("Stop price cannot be negative or zero");
+            }
+
+            if (string.IsNullOrWhiteSpace(notes))
+            {
+                throw new InvalidOperationException("Notes cannot be blank");
+            }
+
+            Apply(new PendingStockPositionCreated(
+                Guid.NewGuid(),
+                Guid.NewGuid(),
+                when: DateTimeOffset.UtcNow,
+                userId: userId,
+                ticker: ticker,
+                price: price,
+                numberOfShares: numberOfShares,
+                stopPrice: stopPrice,
+                notes: notes)
+            );
+        }
+
+        internal void Delete()
+        {
+            Apply(
+                new PendingStockPositionDeleted(
+                    Guid.NewGuid(),
+                    State.Id,
+                    DateTimeOffset.UtcNow
+                )
+            );
+        }
+    }
+}

--- a/src/core/Portfolio/PendingStockPositionState.cs
+++ b/src/core/Portfolio/PendingStockPositionState.cs
@@ -1,0 +1,39 @@
+using System;
+using core.Shared;
+
+namespace core.Portfolio
+{
+    public class PendingStockPositionState : IAggregateState
+    {
+        public Guid Id { get; private set; }
+        public string Ticker { get; private set; }
+        public Guid UserId { get; private set; }
+        public decimal Price { get; private set; }
+        public decimal NumberOfShares { get; private set; }
+        public decimal? StopPrice { get; private set; }
+        public string Notes { get; private set; }
+        public DateTimeOffset Date { get; private set; }
+
+        public void Apply(AggregateEvent e)
+        {
+             ApplyInternal(e);
+        }
+
+        protected void ApplyInternal(dynamic obj)
+        {
+            ApplyInternal(obj);
+        }
+
+        private void ApplyInternal(PendingStockPositionCreated created)
+        {
+            Id = created.Id;
+            Ticker = created.Ticker;
+            UserId = created.UserId;
+            Price = created.Price;
+            NumberOfShares = created.NumberOfShares;
+            StopPrice = created.StopPrice;
+            Notes = created.Notes;
+            Date = created.When;
+        }
+    }
+}

--- a/src/core/Portfolio/PendingStockPositionState.cs
+++ b/src/core/Portfolio/PendingStockPositionState.cs
@@ -26,7 +26,7 @@ namespace core.Portfolio
 
         private void ApplyInternal(PendingStockPositionCreated created)
         {
-            Id = created.Id;
+            Id = created.AggregateId;
             Ticker = created.Ticker;
             UserId = created.UserId;
             Price = created.Price;

--- a/src/web/ClientApp/src/app/app.module.ts
+++ b/src/web/ClientApp/src/app/app.module.ts
@@ -82,6 +82,7 @@ import { StockTradingSimulationsComponent } from './stocks/stock-trading/stock-t
 import { ChartComponent } from './shared/chart/chart.component';
 import { DailyOutcomeScoresComponent } from './shared/reports/daily-outcome-scores.component';
 import { StockTradingReviewDashboardComponent } from './stocks/stock-trading-review/stock-trading-review-dashboard.component';
+import { StockTradingPendingPositionsComponent } from './stocks/stock-trading/stock-trading-pendingpositions.component';
 
 
 var routes: Routes = [
@@ -229,7 +230,8 @@ var routes: Routes = [
     StockListsDashboardComponent,
     StockListComponent,
     ChartComponent,
-    StockTradingReviewDashboardComponent
+    StockTradingReviewDashboardComponent,
+    StockTradingPendingPositionsComponent
   ],
   imports: [
     BrowserModule.withServerTransition({ appId: 'ng-cli-universal' }),

--- a/src/web/ClientApp/src/app/brokerage/orders.component.html
+++ b/src/web/ClientApp/src/app/brokerage/orders.component.html
@@ -1,40 +1,47 @@
-<table class="table" *ngFor="let groupedOrder of groupedOrders">
-  <thead *ngIf="groupedOrder.length > 0">
-    <tr>
-      <th width="100"></th>
-      <th>Stock</th>
-      <th>Type</th>
-      <th>Quantity</th>
-      <th class="text-end">Price</th>
-      <th></th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr *ngFor="let p of groupedOrder; let i = index" [ngClass]="{'table-success': p.isActive && p.type === 'BUY', 'table-info': p.isActive && p.type === 'SELL', 'table-light': !p.isActive}">
-      <td>
-        <div class="small">{{p.status}}</div>
-      </td>
-      <td><a [routerLink]="[ '/stocks', p.ticker ]">{{p.ticker}}</a></td>
-      <td>{{p.type }}</td>
-      <td>{{p.quantity}}</td>
-      <td class="text-end">{{p.price | currency}}</td>
-      <td class="text-end">
-        <button *ngIf="p.canBeCancelled" class="btn btn-warning btn-sm" (click)="cancelOrder(p.orderId)">Cancel</button>
-        <button *ngIf="p.canBeRecorded" class="btn btn-secondary btn-sm" (click)="recordOrder(p)">Record</button>
-      </td>
-    </tr>
-  </tbody>
-  <tfoot  *ngIf="groupedOrder.length > 0">
-    <tr>
-      <td></td>
-      <td></td>
-      <td></td>
-      <td>
-        <b class="float-end">Total</b>
-      </td>
-      <td class="text-end">
-        {{ getTotal(groupedOrder) | currency }}
-      </td>
-      <td></td>
-    </tr>
-</table>
+<div class="card border-info">
+  <div class="card-header">
+    <h5 class="card-title">Brokerage Orders</h5>
+  </div>
+  <div class="card-body">
+    <table class="table" *ngFor="let groupedOrder of groupedOrders">
+      <thead *ngIf="groupedOrder.length > 0">
+        <tr>
+          <th width="100"></th>
+          <th>Stock</th>
+          <th>Type</th>
+          <th>Quantity</th>
+          <th class="text-end">Price</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let p of groupedOrder; let i = index" [ngClass]="{'table-success': p.isActive && p.type === 'BUY', 'table-info': p.isActive && p.type === 'SELL', 'table-light': !p.isActive}">
+          <td>
+            <div class="small">{{p.status}}</div>
+          </td>
+          <td><a [routerLink]="[ '/stocks', p.ticker ]">{{p.ticker}}</a></td>
+          <td>{{p.type }}</td>
+          <td>{{p.quantity}}</td>
+          <td class="text-end">{{p.price | currency}}</td>
+          <td class="text-end">
+            <button *ngIf="p.canBeCancelled" class="btn btn-warning btn-sm" (click)="cancelOrder(p.orderId)">Cancel</button>
+            <button *ngIf="p.canBeRecorded" class="btn btn-secondary btn-sm" (click)="recordOrder(p)">Record</button>
+          </td>
+        </tr>
+      </tbody>
+      <tfoot  *ngIf="groupedOrder.length > 0">
+        <tr>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td>
+            <b class="float-end">Total</b>
+          </td>
+          <td class="text-end">
+            {{ getTotal(groupedOrder) | currency }}
+          </td>
+          <td></td>
+        </tr>
+    </table>
+  </div>
+</div>

--- a/src/web/ClientApp/src/app/services/stocks.service.ts
+++ b/src/web/ClientApp/src/app/services/stocks.service.ts
@@ -107,6 +107,15 @@ export class StocksService {
   }
   // 
 
+  // ----------------- pending positions ---------------------
+  getPendingStockPositions(): Observable<PendingStockPosition[]> {
+    return this.http.get<PendingStockPosition[]>('/api/portfolio/pendingstockpositions')
+  }
+
+  createPendingStockPosition(cmd: stocktransactioncommand): Observable<PendingStockPosition> {
+    return this.http.post<PendingStockPosition>('/api/portfolio/pendingstockpositions', cmd)
+  }
+
   // ----------------- alerts ---------------------
   getAlerts(): Observable<AlertsContainer> {
     return this.http.get<AlertsContainer>('/api/alerts')
@@ -844,6 +853,15 @@ export interface PositionEvent {
   value: number | null,
   type: string,
   description: string,
+}
+
+export interface PendingStockPosition {
+  ticker: string,
+  price: number,
+  numberOfShares: number,
+  stopPrice: number,
+  date: string
+  notes: string
 }
 
 export interface PositionInstance {

--- a/src/web/ClientApp/src/app/services/stocks.service.ts
+++ b/src/web/ClientApp/src/app/services/stocks.service.ts
@@ -116,6 +116,10 @@ export class StocksService {
     return this.http.post<PendingStockPosition>('/api/portfolio/pendingstockpositions', cmd)
   }
 
+  closePendingPosition(id: string): Observable<any> {
+    return this.http.delete<any>('/api/portfolio/pendingstockpositions/' + id)
+  }
+
   // ----------------- alerts ---------------------
   getAlerts(): Observable<AlertsContainer> {
     return this.http.get<AlertsContainer>('/api/alerts')
@@ -856,6 +860,7 @@ export interface PositionEvent {
 }
 
 export interface PendingStockPosition {
+  id: string,
   ticker: string,
   price: number,
   numberOfShares: number,

--- a/src/web/ClientApp/src/app/stocks/stock-buy/stock-new-position.component.html
+++ b/src/web/ClientApp/src/app/stocks/stock-buy/stock-new-position.component.html
@@ -8,7 +8,8 @@
     </app-brokerage-neworder>
 
     <app-stock-trading-newposition
-        (stockPurchased)="stockPurchased()">
+        (stockPurchased)="stockPurchased()"
+        (pendingPositionCreated)="pendingPositionCreated()">
     </app-stock-trading-newposition>
 
     <app-stock-trading-pendingpositions></app-stock-trading-pendingpositions>

--- a/src/web/ClientApp/src/app/stocks/stock-buy/stock-new-position.component.html
+++ b/src/web/ClientApp/src/app/stocks/stock-buy/stock-new-position.component.html
@@ -7,9 +7,11 @@
       (brokerageOrderEntered)="brokerageOrderEntered()">
     </app-brokerage-neworder>
 
-    <app-stock-newposition
+    <app-stock-trading-newposition
         (stockPurchased)="stockPurchased()">
-    </app-stock-newposition>
+    </app-stock-trading-newposition>
+
+    <app-stock-trading-pendingpositions></app-stock-trading-pendingpositions>
 
     <app-brokerage-orders></app-brokerage-orders>
 </div>

--- a/src/web/ClientApp/src/app/stocks/stock-buy/stock-new-position.component.ts
+++ b/src/web/ClientApp/src/app/stocks/stock-buy/stock-new-position.component.ts
@@ -25,8 +25,11 @@ export class StockNewPositionComponent {
 
   stockPurchased() {
     this.feedbackMessage = "Position open recorded";
-    this.pendingPositions.refreshPendingPositions();
   }
 
-
+  pendingPositionCreated() {
+    this.feedbackMessage = "Pending position created";
+    this.pendingPositions.refreshPendingPositions();
+    this.brokerageOrders.refreshOrders();
+  }
 }

--- a/src/web/ClientApp/src/app/stocks/stock-buy/stock-new-position.component.ts
+++ b/src/web/ClientApp/src/app/stocks/stock-buy/stock-new-position.component.ts
@@ -1,5 +1,6 @@
 import { Component, ViewChild } from '@angular/core';
 import { BrokerageOrdersComponent } from 'src/app/brokerage/orders.component';
+import { StockTradingPendingPositionsComponent } from '../stock-trading/stock-trading-pendingpositions.component';
 
 @Component({
   selector: 'app-stock-new-position',
@@ -14,6 +15,9 @@ export class StockNewPositionComponent {
   @ViewChild(BrokerageOrdersComponent)
   private brokerageOrders!: BrokerageOrdersComponent;
 
+  @ViewChild(StockTradingPendingPositionsComponent)
+  private pendingPositions!: StockTradingPendingPositionsComponent;
+
   brokerageOrderEntered() {
     this.feedbackMessage = "Brokerage order entered";
     this.brokerageOrders.refreshOrders();
@@ -21,6 +25,7 @@ export class StockNewPositionComponent {
 
   stockPurchased() {
     this.feedbackMessage = "Position open recorded";
+    this.pendingPositions.refreshPendingPositions();
   }
 
 

--- a/src/web/ClientApp/src/app/stocks/stock-details/stock-details.component.html
+++ b/src/web/ClientApp/src/app/stocks/stock-details/stock-details.component.html
@@ -40,9 +40,9 @@
 
   </div>
 
-  <stock-ownership *ngIf="isActive('stocks')"
+  <app-stock-ownership *ngIf="isActive('stocks')"
     [stock]=stock [ownership]=ownership
-    (ownershipChanged)="stockOwnershipChanged($event)"></stock-ownership>
+    (ownershipChanged)="stockOwnershipChanged($event)"></app-stock-ownership>
 
   <stock-option *ngIf="isActive('options')"
     [ticker]=stock.ticker [options]=options

--- a/src/web/ClientApp/src/app/stocks/stock-details/stock-ownership.component.html
+++ b/src/web/ClientApp/src/app/stocks/stock-details/stock-ownership.component.html
@@ -21,6 +21,8 @@
     </div>
   </div>
 
+  <app-stock-transaction [ticker]="stock.ticker" (transactionRecorded)="transactionRecorded($event)" ></app-stock-transaction>
+
   <app-brokerage-neworder *ngIf="ownership && ownership.currentPosition" (brokerageOrderEntered)="brokerageOrderEntered()"></app-brokerage-neworder>
 
   <app-brokerage-orders *ngIf="stock" [ticker]="stock.ticker"></app-brokerage-orders>

--- a/src/web/ClientApp/src/app/stocks/stock-details/stock-ownership.component.ts
+++ b/src/web/ClientApp/src/app/stocks/stock-details/stock-ownership.component.ts
@@ -5,7 +5,7 @@ import { BrokerageOrdersComponent } from 'src/app/brokerage/orders.component';
 import { GetErrors } from 'src/app/services/utils';
 
 @Component({
-  selector: 'stock-ownership',
+  selector: 'app-stock-ownership',
   templateUrl: './stock-ownership.component.html',
   styleUrls: ['./stock-ownership.component.css'],
 })

--- a/src/web/ClientApp/src/app/stocks/stock-details/stock-transaction.component.html
+++ b/src/web/ClientApp/src/app/stocks/stock-details/stock-transaction.component.html
@@ -1,4 +1,4 @@
-<div class="card mt-4">
+<div class="card mb-3 border-info">
   <div class="card-header">Record trades for {{ticker}}</div>
   <div class="card-body">
     <form>

--- a/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-newposition.component.html
+++ b/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-newposition.component.html
@@ -72,6 +72,9 @@
       </div>
     </div>
     <div class="row mt-3" *ngIf="prices">
+      <div class="col">
+        <button class="btn btn-primary w-100" (click)="createPendingPosition()">Create Pending Position</button>
+      </div>
       <div class="col" >
         <button class="btn btn-primary w-100" (click)="record()">Record</button>
       </div>

--- a/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-newposition.component.html
+++ b/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-newposition.component.html
@@ -72,7 +72,7 @@
       </div>
     </div>
     <div class="row mt-3" *ngIf="prices">
-      <div class="col">
+      <div class="col" *ngIf="!hideCreatePendingPosition">
         <button class="btn btn-primary w-100" (click)="createPendingPosition()">Create Pending Position</button>
       </div>
       <div class="col" >

--- a/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-newposition.component.ts
+++ b/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-newposition.component.ts
@@ -1,6 +1,7 @@
 import { DatePipe } from '@angular/common';
 import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { Prices, SMA, StockAnalysisOutcome, StockGaps, StocksService, stocktransactioncommand, TickerOutcomes } from 'src/app/services/stocks.service';
+import { GetErrors } from 'src/app/services/utils';
 
 @Component({
   selector: 'app-stock-trading-newposition',
@@ -32,6 +33,9 @@ export class StockTradingNewPositionComponent {
 
   @Output()
   stockPurchased: EventEmitter<stocktransactioncommand> = new EventEmitter<stocktransactioncommand>()
+
+  @Output()
+  pendingPositionCreated: EventEmitter<stocktransactioncommand> = new EventEmitter<stocktransactioncommand>()
 
   // variables for new positions
   positionSizeCalculated: number = null
@@ -213,9 +217,13 @@ export class StockTradingNewPositionComponent {
         this.prices = null
         this.gaps = null
         this.outcomes = null
-        this.stockPurchased.emit(cmd)
+        this.pendingPositionCreated.emit(cmd)
       },
-      _ => { alert('purchase failed') }
+      errors => { 
+        var errorMessageArray = GetErrors(errors)
+        var errorMessages = errorMessageArray.join(", ")
+        alert('pending position failed: ' + errorMessages) 
+      }
     )
   }
 

--- a/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-newposition.component.ts
+++ b/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-newposition.component.ts
@@ -3,7 +3,7 @@ import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { Prices, SMA, StockAnalysisOutcome, StockGaps, StocksService, stocktransactioncommand, TickerOutcomes } from 'src/app/services/stocks.service';
 
 @Component({
-  selector: 'app-stock-newposition',
+  selector: 'app-stock-trading-newposition',
   templateUrl: './stock-trading-newposition.component.html',
   styleUrls: ['./stock-trading-newposition.component.css'],
   providers: [DatePipe]
@@ -178,13 +178,7 @@ export class StockTradingNewPositionComponent {
 
   record() {
     console.log("record")
-    var cmd = new stocktransactioncommand()
-    cmd.ticker = this.ticker
-    cmd.numberOfShares = this.numberOfShares
-    cmd.price = this.costToBuy
-    cmd.stopPrice = this.stopPrice
-    cmd.notes = this.notes
-    cmd.date = this.date
+    var cmd = this.createPurchaseCommand();
 
     if (!this.recordPositions) {
       this.stockPurchased.emit(cmd)
@@ -195,6 +189,32 @@ export class StockTradingNewPositionComponent {
       _ => { 
         this.stockPurchased.emit(cmd)
     },
+      _ => { alert('purchase failed') }
+    )
+  }
+
+  private createPurchaseCommand() {
+    var cmd = new stocktransactioncommand();
+    cmd.ticker = this.ticker;
+    cmd.numberOfShares = this.numberOfShares;
+    cmd.price = this.costToBuy;
+    cmd.stopPrice = this.stopPrice;
+    cmd.notes = this.notes;
+    cmd.date = this.date;
+    return cmd;
+  }
+
+  createPendingPosition() {
+    var cmd = this.createPurchaseCommand()
+
+    this.stockService.createPendingStockPosition(cmd).subscribe(
+      _ => {
+        this.ticker = null
+        this.prices = null
+        this.gaps = null
+        this.outcomes = null
+        this.stockPurchased.emit(cmd)
+      },
       _ => { alert('purchase failed') }
     )
   }

--- a/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-newposition.component.ts
+++ b/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-newposition.component.ts
@@ -31,6 +31,9 @@ export class StockTradingNewPositionComponent {
     this.onBuyTickerSelected(ticker)
   }
 
+  @Input()
+  hideCreatePendingPosition: boolean = false
+
   @Output()
   stockPurchased: EventEmitter<stocktransactioncommand> = new EventEmitter<stocktransactioncommand>()
 
@@ -73,6 +76,7 @@ export class StockTradingNewPositionComponent {
         this.ask = quote.askPrice
         this.bid = quote.bidPrice
         this.updateChart(ticker)
+        this.lookupPendingPosition(ticker)
       }, error => {
         console.error(error)
       }
@@ -232,6 +236,22 @@ export class StockTradingNewPositionComponent {
       return []
     }
     return this.outcomes.outcomes.filter(o => o.type !== "Neutral")
+  }
+
+  lookupPendingPosition(ticker: string) {
+    this.stockService.getPendingStockPositions().subscribe(
+      positions => {
+        var position = positions.find(p => p.ticker === ticker)
+        if (position) {
+          this.costToBuy = position.price
+          this.numberOfShares = position.numberOfShares
+          this.stopPrice = position.stopPrice
+          this.notes = position.notes
+          this.date = this.datePipe.transform(position.date, 'yyyy-MM-dd');
+          this.updateBuyingValuesPricesChanged()
+        }
+      }
+    )
   }
 }
 

--- a/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-pendingpositions.component.html
+++ b/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-pendingpositions.component.html
@@ -1,0 +1,36 @@
+<div class="card border-info mb-3">
+  <div class="card-header">
+    <h5 class="card-title">Pending Positions</h5>
+  </div>
+  <div class="card-body">
+    <span *ngIf="positions.length === 0">No pending positions found</span>
+    <table class="table table-striped table-hover" *ngIf="positions.length !== 0">
+      <thead>
+        <tr>
+          <th scope="col">Ticker</th>
+          <th scope="col">Shares</th>
+          <th scope="col">Price</th>
+          <th scope="col">Stop</th>
+          <th scope="col">Date</th>
+        </tr>
+      </thead>
+      <tbody>
+        <ng-container *ngFor="let position of positions">
+          <tr>
+            <td>{{ position.ticker }}</td>
+            <td>{{ position.numberOfShares }}</td>
+            <td>{{ position.price | currency }}</td>
+            <td>{{ position.stopPrice | currency }}</td>
+            <td>{{ position.date | date }}</td>
+          </tr>
+          <tr>
+            <td colspan="5">
+              {{ position.notes }}
+            </td>
+          </tr>
+        </ng-container>
+        
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-pendingpositions.component.html
+++ b/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-pendingpositions.component.html
@@ -12,6 +12,7 @@
           <th scope="col">Price</th>
           <th scope="col">Stop</th>
           <th scope="col">Date</th>
+          <th></th>
         </tr>
       </thead>
       <tbody>
@@ -22,6 +23,9 @@
             <td>{{ position.price | currency }}</td>
             <td>{{ position.stopPrice | currency }}</td>
             <td>{{ position.date | date }}</td>
+            <td class="text-end">
+              <button class="btn btn-warning btn-sm" (click)="closePendingPosition(position)">Close</button>
+            </td>
           </tr>
           <tr>
             <td colspan="5">

--- a/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-pendingpositions.component.ts
+++ b/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-pendingpositions.component.ts
@@ -1,18 +1,15 @@
-import { DatePipe } from '@angular/common';
 import { Component, Output, EventEmitter, OnInit } from '@angular/core';
 import { PendingStockPosition, StocksService, stocktransactioncommand } from 'src/app/services/stocks.service';
 
 @Component({
   selector: 'app-stock-trading-pendingpositions',
   templateUrl: './stock-trading-pendingpositions.component.html',
-  styleUrls: ['./stock-trading-pendingpositions.component.css'],
-  providers: [DatePipe]
+  styleUrls: ['./stock-trading-pendingpositions.component.css']
 })
 export class StockTradingPendingPositionsComponent implements OnInit {
   
   constructor(
-      private stockService:StocksService,
-      private datePipe: DatePipe
+      private stockService:StocksService
       )
   { }
 
@@ -30,7 +27,17 @@ export class StockTradingPendingPositionsComponent implements OnInit {
     this.stockService.getPendingStockPositions().subscribe(
       (data) => {
         this.positions = data;
-        console.log(data)
+      }
+    )
+  }
+
+  closePendingPosition(position: PendingStockPosition) {
+    this.stockService.closePendingPosition(position.id).subscribe(
+      (_) => {
+        this.refreshPendingPositions();
+      },
+      (error) => {
+        console.log(error)
       }
     )
   }

--- a/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-pendingpositions.component.ts
+++ b/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-pendingpositions.component.ts
@@ -1,0 +1,38 @@
+import { DatePipe } from '@angular/common';
+import { Component, Output, EventEmitter, OnInit } from '@angular/core';
+import { PendingStockPosition, StocksService, stocktransactioncommand } from 'src/app/services/stocks.service';
+
+@Component({
+  selector: 'app-stock-trading-pendingpositions',
+  templateUrl: './stock-trading-pendingpositions.component.html',
+  styleUrls: ['./stock-trading-pendingpositions.component.css'],
+  providers: [DatePipe]
+})
+export class StockTradingPendingPositionsComponent implements OnInit {
+  
+  constructor(
+      private stockService:StocksService,
+      private datePipe: DatePipe
+      )
+  { }
+
+  positions: PendingStockPosition[] = [];
+
+  
+  @Output()
+  stockPurchased: EventEmitter<stocktransactioncommand> = new EventEmitter<stocktransactioncommand>()
+
+  ngOnInit(): void {
+    this.refreshPendingPositions()
+  }
+
+  refreshPendingPositions() {
+    this.stockService.getPendingStockPositions().subscribe(
+      (data) => {
+        this.positions = data;
+        console.log(data)
+      }
+    )
+  }
+}
+

--- a/src/web/ClientApp/src/app/stocks/stock-trading/stock-violations.component.html
+++ b/src/web/ClientApp/src/app/stocks/stock-trading/stock-violations.component.html
@@ -17,6 +17,7 @@
           <app-stock-trading-newposition
             *ngIf="activeTicker === violation.ticker && fixType === 'position'"
             [setTicker]="violation.ticker"
+            [hideCreatePendingPosition]="true"
             (stockPurchased)="transactionRecorded($event)">
           </app-stock-trading-newposition>
         </div>

--- a/src/web/ClientApp/src/app/stocks/stock-trading/stock-violations.component.html
+++ b/src/web/ClientApp/src/app/stocks/stock-trading/stock-violations.component.html
@@ -14,11 +14,11 @@
             (transactionFailed)="transactionFailed($event)"
             (transactionRecorded)="transactionRecorded($event)">
           </app-stock-transaction>
-          <app-stock-newposition
+          <app-stock-trading-newposition
             *ngIf="activeTicker === violation.ticker && fixType === 'position'"
             [setTicker]="violation.ticker"
             (stockPurchased)="transactionRecorded($event)">
-          </app-stock-newposition>
+          </app-stock-trading-newposition>
         </div>
       </li>
     </ul>

--- a/src/web/ClientApp/src/app/stocks/stock-trading/stock-violations.component.ts
+++ b/src/web/ClientApp/src/app/stocks/stock-trading/stock-violations.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { stocktransactioncommand, StockViolation } from 'src/app/services/stocks.service';
 
 @Component({
@@ -6,7 +6,7 @@ import { stocktransactioncommand, StockViolation } from 'src/app/services/stocks
   templateUrl: './stock-violations.component.html',
   styleUrls: ['./stock-violations.component.css']
 })
-export class StockViolationsComponent implements OnInit {
+export class StockViolationsComponent {
 
   @Input() violations:StockViolation[] = []
 
@@ -16,9 +16,6 @@ export class StockViolationsComponent implements OnInit {
   fixType : string = null
 
   constructor() { }
-
-  ngOnInit(): void {
-  }
 
   recordTransaction(ticker:string) {
     this.activeTicker = ticker

--- a/src/web/Controllers/PortfolioController.cs
+++ b/src/web/Controllers/PortfolioController.cs
@@ -37,6 +37,10 @@ namespace web.Controllers
             return _mediator.Send(command);
         }
 
+        [HttpDelete("pendingstockpositions/{id}")]
+        public Task DeletePendingStockPosition(Guid id) =>
+            _mediator.Send(new PendingStockPositionClose.Command(id, User.Identifier()));
+
         [HttpGet("stocklists")]
         public Task<StockListState[]> StockLists() =>
             _mediator.Send(new Lists.Query(User.Identifier()));

--- a/src/web/Controllers/PortfolioController.cs
+++ b/src/web/Controllers/PortfolioController.cs
@@ -25,6 +25,18 @@ namespace web.Controllers
             _mediator = mediator;
         }
 
+        [HttpGet("pendingstockpositions")]
+        public Task<IEnumerable<PendingStockPositionState>> PendingStockPositions() =>
+            _mediator.Send(new PendingStockPositionsGet.Query(User.Identifier()));
+
+        [HttpPost("pendingstockpositions")]
+        public Task<PendingStockPositionState> CreatePendingStockPosition([FromBody]PendingStockPositionCreate.Command command)
+        {
+            command.WithUserId(User.Identifier());
+
+            return _mediator.Send(command);
+        }
+
         [HttpGet("stocklists")]
         public Task<StockListState[]> StockLists() =>
             _mediator.Send(new Lists.Query(User.Identifier()));

--- a/tests/coretests/Portfolio/PendingStockPositionTests.cs
+++ b/tests/coretests/Portfolio/PendingStockPositionTests.cs
@@ -1,0 +1,100 @@
+using System;
+using core.Portfolio;
+using Xunit;
+
+namespace coretests.Portfolio
+{
+    public class PendingStockPositionTests
+    {
+        [Fact]
+        public void Create_AppliesProperties()
+        {
+            var pending = new PendingStockPosition(
+                notes: "this is a note",
+                numberOfShares: 100,
+                price: 10,
+                stopPrice: 5,
+                ticker: "AAPL",
+                userId: Guid.NewGuid());
+            
+            Assert.Equal("this is a note", pending.State.Notes);
+            Assert.Equal(100, pending.State.NumberOfShares);
+            Assert.Equal(10, pending.State.Price);
+            Assert.Equal(5, pending.State.StopPrice);
+            Assert.Equal("AAPL", pending.State.Ticker);
+            Assert.NotEqual(Guid.Empty, pending.State.UserId);
+        }
+
+        [Fact]
+        public void Create_WithInvalidPrice_Throws()
+        {
+            Assert.Throws<InvalidOperationException>(() => new PendingStockPosition(
+                notes: "this is a note",
+                numberOfShares: 100,
+                price: 0,
+                stopPrice: 5,
+                ticker: "AAPL",
+                userId: Guid.NewGuid()));
+        }
+
+        [Fact]
+        public void Create_WithInvalidNumberOfShares_Throws()
+        {
+            Assert.Throws<InvalidOperationException>(() => new PendingStockPosition(
+                notes: "this is a note",
+                numberOfShares: 0,
+                price: 10,
+                stopPrice: 5,
+                ticker: "AAPL",
+                userId: Guid.NewGuid()));
+        }
+
+        [Fact]
+        public void Create_WithInvalidStopPrice_Throws()
+        {
+            Assert.Throws<InvalidOperationException>(() => new PendingStockPosition(
+                notes: "this is a note",
+                numberOfShares: 100,
+                price: 10,
+                stopPrice: -1,
+                ticker: "AAPL",
+                userId: Guid.NewGuid()));
+        }
+
+        [Fact]
+        public void Create_WithInvalidNotes_Throws()
+        {
+            Assert.Throws<InvalidOperationException>(() => new PendingStockPosition(
+                notes: "",
+                numberOfShares: 100,
+                price: 10,
+                stopPrice: 5,
+                ticker: "AAPL",
+                userId: Guid.NewGuid()));
+        }
+
+        [Fact]
+        public void Create_WithInvalidUserId_Throws()
+        {
+            Assert.Throws<InvalidOperationException>(() => new PendingStockPosition(
+                notes: "this is a note",
+                numberOfShares: 100,
+                price: 10,
+                stopPrice: 5,
+                ticker: "AAPL",
+                userId: Guid.Empty));
+        }
+
+        [Fact]
+        public void Create_WithInvalidTicker_Throws()
+        {
+            Assert.Throws<ArgumentException>(() => new PendingStockPosition(
+                notes: "this is a note",
+                numberOfShares: 100,
+                price: 10,
+                stopPrice: 5,
+                ticker: "",
+                userId: Guid.NewGuid()));
+        }
+    }
+}

--- a/tests/storagetests/memory/MemoryPortfolioStorageTests.cs
+++ b/tests/storagetests/memory/MemoryPortfolioStorageTests.cs
@@ -2,11 +2,16 @@
 using storage.memory;
 using storage.shared;
 using storage.tests;
+using Xunit.Abstractions;
 
 namespace storagetests.memory
 {
     public class MemoryPortfolioStorageTests : PortfolioStorageTests
     {
+        public MemoryPortfolioStorageTests(ITestOutputHelper output) : base(output)
+        {
+        }
+        
         protected override IPortfolioStorage CreateStorage()
         {
             return new PortfolioStorage(

--- a/tests/storagetests/postgres/PostgresPortfolioStorageTests.cs
+++ b/tests/storagetests/postgres/PostgresPortfolioStorageTests.cs
@@ -9,6 +9,7 @@ using storage.shared;
 using storage.tests;
 using testutils;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace storagetests.postgres
 {
@@ -17,7 +18,7 @@ namespace storagetests.postgres
     {
         protected string _cnn = null;
 
-        public PostgresPortfolioStorageTests()
+        public PostgresPortfolioStorageTests(ITestOutputHelper output) : base(output)
         {
             _cnn = CredsHelper.GetDbCreds();
         }


### PR DESCRIPTION
This PR creates the ability for the user to start a "pending position." Whenever user wants to establish a position in a stock, they go through the process of determining the price they want to get in at, as well as the stops, and write down notes explaining the thinking process behind the position as well as potentially add instructions for the future selfs as to how the position should be managed.

Example:

![image](https://user-images.githubusercontent.com/911757/220447810-a3907c1e-f188-477f-8b35-5d3cf86b204b.png)

Creating a pending position issues a limit buy order with user's configured brokerage. And in case the order is executed, the violations screen where orders are reconciled will copy over the pending order information into the actual position open request.

This way user does not have to go back and redo the thoughts/stop information for the second time.