### PR TITLE
Introduce a concept of labels that can be added to positions

### DIFF
--- a/src/core/Portfolio/Handlers/PositionLabelsRemove.cs
+++ b/src/core/Portfolio/Handlers/PositionLabelsRemove.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using core.Account;
+using core.Shared;
+using MediatR;
+
+namespace core.Portfolio
+{
+    public class PositionLabelsDelete
+    {
+        public class Command : RequestWithUserId<Unit>
+        {
+            public Command(string ticker, int positionId, string key, Guid userId)
+            {
+                UserId = userId;
+                PositionId = positionId;
+                Ticker = ticker;
+                Key = key;
+            }
+
+            public int PositionId { get; }
+            public string Ticker { get; }
+            public string Key { get; }
+        }
+
+        public class Handler : HandlerWithStorage<Command, Unit>
+        {
+            private IAccountStorage _accounts;
+
+            public Handler(IAccountStorage accounts, IPortfolioStorage storage) : base(storage)
+            {
+                _accounts = accounts;
+            }
+
+            public override async Task<Unit> Handle(Command request, CancellationToken cancellationToken)
+            {
+                var user = await _accounts.GetUser(request.UserId);
+                if (user == null)
+                {
+                    throw new Exception("User not found");
+                }
+
+                var stock = await _storage.GetStock(request.Ticker, request.UserId);
+                if (stock == null)
+                {
+                    throw new Exception("Stock not found");
+                }
+
+                stock.DeletePositionLabel(request.PositionId, request.Key);
+
+                await _storage.Save(stock, request.UserId);
+
+                return new Unit();
+            }
+        }
+    }
+}

--- a/src/core/Portfolio/Handlers/PositionLabelsSet.cs
+++ b/src/core/Portfolio/Handlers/PositionLabelsSet.cs
@@ -1,0 +1,56 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Threading;
+using System.Threading.Tasks;
+using core.Account;
+using core.Shared;
+using MediatR;
+
+namespace core.Portfolio
+{
+    public class PositionLabelsSet
+    {
+        public class Command : RequestWithUserId<Unit>
+        {
+            [Required]
+            public string Ticker { get; set; }
+            [Required]
+            public int PositionId { get; set; }
+            [Required]
+            public string Key { get; set; }
+            [Required]
+            public string Value { get; set; }
+        }
+
+        public class Handler : HandlerWithStorage<Command, Unit>
+        {
+            private IAccountStorage _accounts;
+
+            public Handler(IAccountStorage accounts, IPortfolioStorage storage) : base(storage)
+            {
+                _accounts = accounts;
+            }
+
+            public override async Task<Unit> Handle(Command request, CancellationToken cancellationToken)
+            {
+                var user = await _accounts.GetUser(request.UserId);
+                if (user == null)
+                {
+                    throw new Exception("User not found");
+                }
+
+                var stock = await _storage.GetStock(request.Ticker, request.UserId);
+                if (stock == null)
+                {
+                    throw new Exception("Stock not found");
+                }
+
+                stock.SetPositionLabel(request.PositionId, request.Key, request.Value);
+
+                await _storage.Save(stock, request.UserId);
+
+                return new Unit();
+            }
+        }
+    }
+}

--- a/src/core/Stocks/Events.cs
+++ b/src/core/Stocks/Events.cs
@@ -220,4 +220,36 @@ namespace core.Stocks
         public int PositionId { get; }
         public Guid UserId { get; }
     }
+
+    public class PositionLabelSet : AggregateEvent
+    {
+        public PositionLabelSet(Guid id, Guid aggregateId, DateTimeOffset when, Guid userId, int positionId, string key, string value) :
+            base(id, aggregateId, when)
+        {
+            UserId = userId;
+            PositionId = positionId;
+            Key = key;
+            Value = value;
+        }
+
+        public Guid UserId { get; }
+        public int PositionId { get; }
+        public string Key { get; }
+        public string Value { get; }
+    }
+
+    public class PositionLabelDeleted : AggregateEvent
+    {
+        public PositionLabelDeleted(Guid id, Guid aggregateId, DateTimeOffset when, Guid userId, int positionId, string key) :
+            base(id, aggregateId, when)
+        {
+            UserId = userId;
+            PositionId = positionId;
+            Key = key;
+        }
+
+        public Guid UserId { get; }
+        public int PositionId { get; }
+        public string Key { get; }
+    }
 }

--- a/src/core/Stocks/OwnedStock.cs
+++ b/src/core/Stocks/OwnedStock.cs
@@ -284,5 +284,75 @@ namespace core.Stocks
 
             return true;
         }
+
+        internal bool SetPositionLabel(int positionId, string key, string value)
+        {
+            var position = State.GetPosition(positionId);
+            if (position == null)
+            {
+                throw new InvalidOperationException("Unable to find position with id " + positionId);
+            }
+
+            if (string.IsNullOrEmpty(key))
+            {
+                throw new InvalidOperationException("Key cannot be empty");
+            }
+
+            if (string.IsNullOrEmpty(value))
+            {
+                throw new InvalidOperationException("Value cannot be empty");
+            }
+
+            if (position.ContainsLabel(key, value))
+            {
+                return false;
+            }
+
+            Apply(
+                new PositionLabelSet(
+                    Guid.NewGuid(),
+                    State.Id,
+                    DateTimeOffset.UtcNow,
+                    State.UserId,
+                    positionId,
+                    key,
+                    value
+                )
+            );
+
+            return true;
+        }
+
+        internal bool DeletePositionLabel(int positionId, string key)
+        {
+            var position = State.GetPosition(positionId);
+            if (position == null)
+            {
+                throw new InvalidOperationException("Unable to find position with id " + positionId);
+            }
+
+            if (string.IsNullOrEmpty(key))
+            {
+                throw new InvalidOperationException("Key cannot be empty");
+            }
+
+            if (!position.ContainsLabel(key))
+            {
+                return false;
+            }
+
+            Apply(
+                new PositionLabelDeleted(
+                    Guid.NewGuid(),
+                    State.Id,
+                    DateTimeOffset.UtcNow,
+                    State.UserId,
+                    positionId,
+                    key
+                )
+            );
+
+            return true;
+        }
     }
 }

--- a/src/core/Stocks/OwnedStockState.cs
+++ b/src/core/Stocks/OwnedStockState.cs
@@ -227,6 +227,18 @@ namespace core.Stocks
             }
         }
 
+        private void ApplyInternal(PositionLabelSet labelSet)
+        {
+            var position = Positions.Single(x => x.PositionId == labelSet.PositionId);
+            position.SetLabel(labelSet);
+        }
+
+        private void ApplyInternal(PositionLabelDeleted labelDeleted)
+        {
+            var position = Positions.Single(x => x.PositionId == labelDeleted.PositionId);
+            position.DeleteLabel(labelDeleted);
+        }
+
         public void Apply(AggregateEvent e)
         {
             ApplyInternal(e);

--- a/src/core/Stocks/PositionInstance.cs
+++ b/src/core/Stocks/PositionInstance.cs
@@ -67,7 +67,6 @@ namespace core.Stocks
         public List<PositionTransaction> Transactions { get; private set; } = new List<PositionTransaction>();
         public List<PositionEvent> Events { get; private set; } = new List<PositionEvent>();
 
-        public List<string> Notes { get; private set; } = new List<string>();
         public decimal? StopPrice { get; private set; }
         public DateTimeOffset LastTransaction { get; private set; }
         public decimal LastSellPrice { get; private set; }
@@ -92,6 +91,7 @@ namespace core.Stocks
             Notes.Add(note);
         }
 
+        public List<string> Notes { get; private set; } = new List<string>();
         public void AddNotes(string notes)
         {
             Notes.Add(notes);
@@ -298,6 +298,33 @@ namespace core.Stocks
                 0 => 0,
                 _ => totalBuy / totalNumberOfSharesBought
             };
+        }
+
+        private Dictionary<string, string> _labels { get; set; } = new Dictionary<string, string>();
+        public IEnumerable<KeyValuePair<string, string>> Labels => _labels;
+        internal bool ContainsLabel(string key, string value)
+        {
+            if (!ContainsLabel(key))
+            {
+                return false;
+            }
+
+            return _labels[key] == value;
+        }
+
+        internal void SetLabel(PositionLabelSet labelSet)
+        {
+            _labels[labelSet.Key] = labelSet.Value;
+        }
+
+        internal bool ContainsLabel(string key)
+        {
+            return _labels.ContainsKey(key);
+        }
+
+        internal void DeleteLabel(PositionLabelDeleted labelDeleted)
+        {
+            _labels.Remove(labelDeleted.Key);
         }
     }
 }

--- a/src/web/ClientApp/src/app/services/stocks.service.ts
+++ b/src/web/ClientApp/src/app/services/stocks.service.ts
@@ -60,6 +60,20 @@ export class StocksService {
     return this.http.delete(`/api/portfolio/${ticker}/positions/${positionId}`)
   }
 
+  setLabel(ticker: string, positionId: number, label: PositionInstanceLabel): Observable<object> {
+    return this.http.post(`/api/portfolio/${ticker}/positions/${positionId}/labels`, {
+      key: label.key,
+      value: label.value,
+      ticker: ticker,
+      positionId: positionId
+    })
+  }
+
+  deleteLabel(ticker: string, positionId: number, labelKey: string): Observable<object> {
+    return this.http.delete(`/api/portfolio/${ticker}/positions/${positionId}/labels/${labelKey}`)
+  }
+
+  // ----------------- alerts ---------------------
   smsOff(): Observable<any> {
     return this.http.post<any>('/api/alerts/sms/off', {})
   }
@@ -948,6 +962,11 @@ export interface PendingStockPosition {
   notes: string
 }
 
+export interface PositionInstanceLabel {
+  key: string,
+  value: string
+}
+
 export interface PositionInstance {
   positionId: number,
   averageBuyCostPerShare: number,
@@ -967,6 +986,7 @@ export interface PositionInstance {
   isShortTerm: boolean,
   lastTransaction: string,
   notes: string[],
+  labels: PositionInstanceLabel[],
   numberOfShares: number,
   opened: string,
   price: number,

--- a/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-position.component.html
+++ b/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-position.component.html
@@ -67,7 +67,24 @@
         <a href="#" (click)="deleteStopPrice();">Delete Stop Price</a>
       </div>
     </div>
-    <div class="col"></div>
+    <div class="col">
+      <label class="form-label" for="setStrategy">Strategy</label>
+      <div class="input-group">
+        <select class="form-select" id="strategyInput" #strategyInput value="{{positionStrategy}}">
+          <option value="">Choose...</option>
+          <option value="newhigh">New High</option>
+          <option value="resistancebreakthrough">Resistance Breakthrough</option>
+          <option value="newhighpullback">New High Pullback</option>
+          <option value="recovery">Recovery</option>
+          <option value="postearnings">Post Earnings</option>
+          <option value="postearningsnewhigh">Post Earnings New High</option>
+        </select>
+        <button class="btn btn-secondary" (click)="setStrategy(strategyInput.value)">Update</button>
+      </div>
+      <div>
+        <a href="#" (click)="strategyInput.value = ''; clearStrategy();">Clear Strategy</a>
+      </div>
+    </div>
     <div class="col"></div>
   </div>
 

--- a/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-position.component.ts
+++ b/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-position.component.ts
@@ -15,10 +15,12 @@ export class StockTradingPositionComponent {
     _position: PositionInstance;
 
     positionProfitPoints : StrategyProfitPoint[] = []
+    positionStrategy: string = null
 
     @Input()
     set position(v:PositionInstance) {
         this._position = v
+        this.positionStrategy = v.labels.find(l => l.key == "strategy")?.value
         this.positionProfitPoints = []
         if (this._position) {
             this.setCandidateValues()
@@ -99,6 +101,38 @@ export class StockTradingPositionComponent {
                     this.positionDeleted.emit()
                 })
         }
+    }
+
+    clearStrategy() {
+        this.stockService.deleteLabel(this._position.ticker, this._position.positionId, "strategy").subscribe(
+            (r) => {
+            },
+            (err) => {
+                alert("Error clearing strategy")
+            }
+        )
+
+        return false
+    }
+
+    setStrategy(strategy:string) {
+        if (!strategy) {
+            alert("Please select strategy")
+            return
+        }
+
+        let label = {
+            key: "strategy",
+            value: strategy
+        }
+
+        this.stockService.setLabel(this._position.ticker, this._position.positionId, label).subscribe(
+            (r) => {
+            },
+            (err) => {
+                alert("Error setting strategy")
+            }
+        )
     }
 
     toggleVisibility(elem) {

--- a/src/web/Controllers/PortfolioController.cs
+++ b/src/web/Controllers/PortfolioController.cs
@@ -211,6 +211,27 @@ namespace web.Controllers
                 )
             );
 
+        [HttpPost("{ticker}/positions/{positionId}/labels")]
+        public Task SetLabel(
+            int positionId,
+            string ticker,
+            [FromBody]PositionLabelsSet.Command command)
+        {
+            command.WithUserId(User.Identifier());
+
+            return _mediator.Send(command);
+        }
+
+        [HttpDelete("{ticker}/positions/{positionId}/labels/{label}")]
+        public Task RemoveLabel(
+            int positionId,
+            string ticker,
+            string label) => _mediator.Send(
+                new PositionLabelsDelete.Command(
+                    ticker, positionId, label, User.Identifier()
+                )
+            );
+
         [HttpGet("{ticker}/simulate/trades")]
         public Task<TradingStrategyResults> Trade(
             string ticker,

--- a/tests/coretests/Stocks/OwnedStockTests.cs
+++ b/tests/coretests/Stocks/OwnedStockTests.cs
@@ -402,5 +402,80 @@ namespace coretests.Stocks
             Assert.Equal(2, stock.State.Transactions.Count(t => t.IsPL));
             Assert.Equal(4, stock.State.Transactions.Count(t => !t.IsPL));
         }
+
+        [Fact]
+        public void LabelsWork()
+        {
+            var stock = new OwnedStock("tsla", _userId);
+
+            stock.Purchase(1, 5, DateTimeOffset.UtcNow.AddDays(-5));
+            var positionId = stock.State.OpenPosition.PositionId;
+            
+            var set = stock.SetPositionLabel(positionId, "strategy", "newhigh");
+            Assert.True(set);
+
+            var setAgain = stock.SetPositionLabel(positionId, "strategy", "newhigh");
+            Assert.False(setAgain);
+
+            var setDifferent = stock.SetPositionLabel(positionId, "strategy", "newlow");
+            Assert.True(setDifferent);
+        }
+
+        [Fact]
+        public void SetLabel_WithNullValue_Fails()
+        {
+            var stock = new OwnedStock("tsla", _userId);
+
+            stock.Purchase(1, 5, DateTimeOffset.UtcNow.AddDays(-5));
+            var positionId = stock.State.OpenPosition.PositionId;
+            
+            Assert.Throws<InvalidOperationException>(() => 
+                stock.SetPositionLabel(positionId, "strategy", null)
+            );
+        }
+
+        [Fact]
+        public void SetLabel_WithNullKey_Fails()
+        {
+            var stock = new OwnedStock("tsla", _userId);
+
+            stock.Purchase(1, 5, DateTimeOffset.UtcNow.AddDays(-5));
+            var positionId = stock.State.OpenPosition.PositionId;
+            
+            Assert.Throws<InvalidOperationException>(() => 
+                stock.SetPositionLabel(positionId, null, "newhigh")
+            );
+        }
+
+        [Fact]
+        public void DeleteLabel_Works()
+        {
+            var stock = new OwnedStock("tsla", _userId);
+
+            stock.Purchase(1, 5, DateTimeOffset.UtcNow.AddDays(-5));
+            var positionId = stock.State.OpenPosition.PositionId;
+            
+            var set = stock.SetPositionLabel(positionId, "strategy", "newhigh");
+            Assert.True(set);
+
+            var deleted = stock.DeletePositionLabel(positionId, "strategy");
+            Assert.True(deleted);
+
+            var deletedAgain = stock.DeletePositionLabel(positionId, "strategy");
+            Assert.False(deletedAgain);
+        }
+
+        [Fact]
+        public void DeleteLabel_WithNullKey_Fails()
+        {
+            var stock = new OwnedStock("tsla", _userId);
+
+            stock.Purchase(1, 5, DateTimeOffset.UtcNow.AddDays(-5));
+            var positionId = stock.State.OpenPosition.PositionId;
+            
+            Assert.Throws<InvalidOperationException>(() => 
+                stock.DeletePositionLabel(positionId, null)
+            );
+        }
     }
 }


### PR DESCRIPTION
This will allow to add labels to positions and use that concept in variety of ways. The first usage I am going for is ability to set an entry strategy for the position. What was the reason for entry, or which strategy was used to enter the position. Was it new high? post earnings breakout? Recovery play? Something custom? The UI allows user to set the strategy. Behind the scenes, the concept of labels that contain key/value pairs is used to store the chosen strategy.

I am considering moving "category" to label concept to. Is the position long term? short term? This could be modeled as "category:longterm".