### PR TITLE
UserId explicit type

### DIFF
--- a/src/core.fs/Accounts/Handlers.fs
+++ b/src/core.fs/Accounts/Handlers.fs
@@ -75,7 +75,7 @@ namespace core.fs.Accounts
                 Feedback: string
             }
         
-            member this.WithUserId (userId:UserId) = { this with UserId = userId }
+            member this.WithUserId userId = { this with UserId = userId }
        
         
         type Handler(storage:IAccountStorage, portfolio:IPortfolioStorage, email:IEmailService) =

--- a/src/core.fs/Admin/Handlers.fs
+++ b/src/core.fs/Admin/Handlers.fs
@@ -9,6 +9,7 @@ namespace core.fs.Admin
     open core.Stocks
     open core.fs.Shared
     open core.fs.Shared.Adapters.Storage
+    open core.fs.Shared.Domain.Accounts
 
     module Users =
         
@@ -52,9 +53,7 @@ namespace core.fs.Admin
                     
                     let! result = 
                         users
-                        |> Seq.map (fun emailId -> async {
-                            return! emailId.Id |> Guid |> buildQueryResponse
-                        })
+                        |> Seq.map (fun emailId -> emailId.Id |> buildQueryResponse)
                         |> Async.Parallel
                         |> Async.StartAsTask
                         
@@ -66,9 +65,9 @@ namespace core.fs.Admin
                 
                 let! userTasks = 
                     pairs
-                    |> Seq.map (fun emailId -> async {
-                        return! emailId.Id |> Guid |> storage.GetUser |> Async.AwaitTask
-                    })
+                    |> Seq.map (fun emailId ->
+                        emailId.Id |> storage.GetUser |> Async.AwaitTask
+                    )
                     |> Async.Parallel
                     |> Async.StartAsTask
                     

--- a/src/core.fs/Alerts/Handlers.fs
+++ b/src/core.fs/Alerts/Handlers.fs
@@ -1,14 +1,16 @@
 namespace core.fs.Alerts
 
-    open System
     open core.Shared
     open core.Shared.Adapters.SMS
     open core.Stocks
     open core.fs.Shared
+    open core.fs.Shared.Domain.Accounts
 
     module AlertContainer =
         
-        type Query = { UserId:Guid;}
+        type Query = {
+            UserId:UserId
+        }
         type QueryAvailableMonitors = struct end
         type Run = struct end
         
@@ -22,13 +24,13 @@ namespace core.fs.Alerts
                 container.RequestManualRun()
                 
             member this.Handle(stockSold:StockSold) =
-                stockSold.Ticker |> Ticker |> deregisterStopPriceMonitoring stockSold.UserId
+                stockSold.Ticker |> Ticker |> deregisterStopPriceMonitoring (stockSold.UserId |> UserId)
                 
             member this.Handle(stopPriceSet:StopPriceSet) =
-                stopPriceSet.Ticker |> Ticker |> deregisterStopPriceMonitoring stopPriceSet.UserId
+                stopPriceSet.Ticker |> Ticker |> deregisterStopPriceMonitoring (stopPriceSet.UserId |> UserId)
                 
             member this.Handle(stopDeleted:StopDeleted) =
-                stopDeleted.Ticker |> Ticker |> deregisterStopPriceMonitoring stopDeleted.UserId
+                stopDeleted.Ticker |> Ticker |> deregisterStopPriceMonitoring (stopDeleted.UserId |> UserId)
                 
             member this.Handle(query:Query) =
                 let alerts = 

--- a/src/core.fs/Alerts/StockAlertContainer.fs
+++ b/src/core.fs/Alerts/StockAlertContainer.fs
@@ -142,7 +142,7 @@ namespace core.fs.Alerts
             { Ticker = ticker; UserId = userId }
             |> alerts.TryRemove |> ignore
             
-        member _.GetRecentlyTriggered (userId:UserId) =
+        member _.GetRecentlyTriggered userId =
             let list =
                 match recentlyTriggered.TryGetValue(userId) with
                 | true, alerts -> alerts
@@ -150,7 +150,7 @@ namespace core.fs.Alerts
             
             list |> List.sortByDescending (fun x -> x.``when``)
             
-        member _.GetAlerts (userId:UserId) =
+        member _.GetAlerts userId =
             alerts.Values
             |> Seq.filter (fun alert -> alert.userId = userId)
             |> Seq.sortBy (fun x -> x.sourceList,x.ticker.Value)

--- a/src/core.fs/Alerts/StockAlertContainer.fs
+++ b/src/core.fs/Alerts/StockAlertContainer.fs
@@ -5,10 +5,11 @@ namespace core.fs.Alerts
     open core.Account
     open core.Shared
     open core.Stocks.Services.Analysis
+    open core.fs.Shared.Domain.Accounts
 
     type private StockPositionMonitorKey = {
         Ticker: Ticker
-        UserId: Guid
+        UserId: UserId
     }
     
     [<Struct>]
@@ -44,7 +45,7 @@ namespace core.fs.Alerts
             ticker:Ticker
             description:string
             sourceList:string
-            userId:Guid
+            userId:UserId
             alertType:AlertType
             valueFormat:ValueFormat
         }
@@ -95,7 +96,7 @@ namespace core.fs.Alerts
         
     type StockAlertContainer() =
         let alerts = ConcurrentDictionary<StockPositionMonitorKey, TriggeredAlert>()
-        let recentlyTriggered = ConcurrentDictionary<Guid, List<TriggeredAlert>>()
+        let recentlyTriggered = ConcurrentDictionary<UserId, List<TriggeredAlert>>()
         let notices = System.Collections.Generic.List<AlertContainerMessage>(capacity=10)
         
         let mutable manualRun = false
@@ -141,7 +142,7 @@ namespace core.fs.Alerts
             { Ticker = ticker; UserId = userId }
             |> alerts.TryRemove |> ignore
             
-        member _.GetRecentlyTriggered (userId:Guid) =
+        member _.GetRecentlyTriggered (userId:UserId) =
             let list =
                 match recentlyTriggered.TryGetValue(userId) with
                 | true, alerts -> alerts
@@ -149,7 +150,7 @@ namespace core.fs.Alerts
             
             list |> List.sortByDescending (fun x -> x.``when``)
             
-        member _.GetAlerts (userId:Guid) =
+        member _.GetAlerts (userId:UserId) =
             alerts.Values
             |> Seq.filter (fun alert -> alert.userId = userId)
             |> Seq.sortBy (fun x -> x.sourceList,x.ticker.Value)

--- a/src/core.fs/Brokerage/Handlers.fs
+++ b/src/core.fs/Brokerage/Handlers.fs
@@ -6,6 +6,7 @@ module core.fs.Brokerage
     open core.Shared.Adapters.Brokerage
     open core.fs.Shared
     open core.fs.Shared.Adapters.Storage
+    open core.fs.Shared.Domain.Accounts
 
     type BuyOrSellData =
         {
@@ -22,18 +23,18 @@ module core.fs.Brokerage
         }
         
     type BrokerageTransaction =
-        | Buy of BuyOrSellData * Guid
-        | Sell of BuyOrSellData * Guid
+        | Buy of BuyOrSellData * UserId
+        | Sell of BuyOrSellData * UserId
         
     type CancelOrder =
         {
-            UserId:Guid
+            UserId:UserId
             OrderId:string
         }
         
     type QueryAccount =
         {
-            UserId:Guid
+            UserId:UserId
         }
         
     type Handler(accounts:IAccountStorage, brokerage:IBrokerage) =

--- a/src/core.fs/Cryptos/Handlers.fs
+++ b/src/core.fs/Cryptos/Handlers.fs
@@ -9,6 +9,7 @@ namespace core.fs.Cryptos
     open core.fs.Cryptos.Import
     open core.fs.Shared
     open core.fs.Shared.Adapters.Storage
+    open core.fs.Shared.Domain.Accounts
     
     type CryptoTransaction =
         {
@@ -24,19 +25,19 @@ namespace core.fs.Cryptos
         }
         
     type CryptoTransactionWithUserId =
-        | Buy of CryptoTransaction * Guid
-        | Sell of CryptoTransaction * Guid
-        | Reward of CryptoTransaction * Guid
-        | Yield of CryptoTransaction * Guid
+        | Buy of CryptoTransaction * UserId
+        | Sell of CryptoTransaction * UserId
+        | Reward of CryptoTransaction * UserId
+        | Yield of CryptoTransaction * UserId
         
     type DashboardQuery =
         {
-            UserId:Guid
+            UserId:UserId
         }
         
     type DeleteTransaction =
         {
-            UserId:Guid
+            UserId:UserId
             TransactionId:Guid
             Token:Token
         }
@@ -48,24 +49,24 @@ namespace core.fs.Cryptos
         
     type Export =
         {
-            UserId:Guid
+            UserId:UserId
         }
         
     type ImportBlockFi =
         {
-            UserId:Guid
+            UserId:UserId
             Content:string
         }
         
     type ImportCoinbase =
         {
-            UserId:Guid
+            UserId:UserId
             Content:string
         }
         
     type ImportCoinbasePro =
         {
-            UserId:Guid
+            UserId:UserId
             Content:string
         }
         
@@ -77,7 +78,7 @@ namespace core.fs.Cryptos
     type OwnershipQuery =
         {
             Token:Token
-            UserId:Guid
+            UserId:UserId
         }
     
     type OwnedCryptoView(owned:OwnedCryptoState) =
@@ -151,7 +152,7 @@ namespace core.fs.Cryptos
                 else            
                     let cryptoToUse =
                         match crypto with
-                        | null -> OwnedCrypto(data.Token, userId)
+                        | null -> OwnedCrypto(data.Token, userId |> IdentifierHelper.getUserId)
                         | _ -> crypto
                         
                     func data cryptoToUse

--- a/src/core.fs/ImportTransactions.fs
+++ b/src/core.fs/ImportTransactions.fs
@@ -9,6 +9,7 @@ open core.Shared.Adapters.Emails
 open core.fs.Options
 open core.fs.Shared
 open core.fs.Shared.Adapters.Storage
+open core.fs.Shared.Domain.Accounts
 open core.fs.Stocks
 
 module ImportTransactions =
@@ -16,7 +17,7 @@ module ImportTransactions =
     type Command =
         {
             Content:string
-            UserId:Guid
+            UserId:UserId
         }
         
     type internal TransactionRecord =

--- a/src/core.fs/Notes/Handlers.fs
+++ b/src/core.fs/Notes/Handlers.fs
@@ -7,6 +7,7 @@ namespace core.fs.Notes
     open core.Shared.Adapters.CSV
     open core.fs.Shared
     open core.fs.Shared.Adapters.Storage
+    open core.fs.Shared.Domain.Accounts
 
     type AddNote = 
         {
@@ -14,7 +15,7 @@ namespace core.fs.Notes
             Note: string
             [<Required>]
             Ticker: Ticker
-            UserId: Guid
+            UserId: UserId
         }
         
     type UpdateNote = 
@@ -23,34 +24,34 @@ namespace core.fs.Notes
             NoteId: Guid
             [<Required>]
             Note: string
-            UserId: Guid
+            UserId: UserId
         }
         
     type GetNote =
         {
             NoteId: Guid
-            UserId: Guid
+            UserId: UserId
         }
         
     type GetNotes =
         {
-            UserId: Guid
+            UserId: UserId
         }
         
     type GetNotesForTicker =
         {
             Ticker: Ticker
-            UserId: Guid
+            UserId: UserId
         }
         
     type Export = 
         {
-            UserId: Guid
+            UserId: UserId
         }
         
     type Import = 
         {
-            UserId: Guid
+            UserId: UserId
             Content: string
         }
         
@@ -75,7 +76,7 @@ namespace core.fs.Notes
             match user with
             | None -> return "User not found" |> ResponseUtils.failedTyped<Note>
             | _ -> 
-                let note = Note(userId=command.UserId,ticker=command.Ticker,note=command.Note,created=DateTime.UtcNow)
+                let note = Note(userId=(command.UserId |> IdentifierHelper.getUserId),ticker=command.Ticker,note=command.Note,created=DateTime.UtcNow)
                 do! portfolio.SaveNote note command.UserId
                 return note |> ResponseUtils.success<Note>
         }

--- a/src/core.fs/Options/Import.fs
+++ b/src/core.fs/Options/Import.fs
@@ -3,6 +3,7 @@ namespace core.fs.Options
 open System
 open core.Shared.Adapters.CSV
 open core.fs.Shared
+open core.fs.Shared.Domain.Accounts
 
 module Import =
     open core.Shared
@@ -18,13 +19,13 @@ module Import =
         ``type``:string
     }
           
-    type Command(content:string,userId:Guid) =
+    type Command(content:string,userId:UserId) =
         member _.UserId = userId
         member _.Content = content
 
     type Handler(csvParser:ICSVParser, optionHandler:core.fs.Options.Handler) =
         
-        let processCommand record (command:Object) userId token =
+        let processCommand record (command:Object) _ _ =
             match command with
             
             | :? ExpireViaLookupCommand as expCommand ->

--- a/src/core.fs/Portfolio/Handler.fs
+++ b/src/core.fs/Portfolio/Handler.fs
@@ -39,7 +39,7 @@ type GradePosition =
         Note: string
     }
     
-    static member WithUserId (userId:UserId) (command:GradePosition) = { command with UserId = userId }
+    static member WithUserId userId (command:GradePosition) = { command with UserId = userId }
     
 type RemoveLabel =
     {
@@ -64,7 +64,7 @@ type AddLabel =
         Value: string
     }
     
-    static member WithUserId (userId:UserId) (command:AddLabel) = { command with UserId = userId }
+    static member WithUserId userId (command:AddLabel) = { command with UserId = userId }
     
 type ProfitPointsQuery =
     {
@@ -85,7 +85,7 @@ type SetRisk =
         [<Required>]
         RiskAmount: Nullable<decimal>
     }
-    static member WithUserId (userId:UserId) (command:SetRisk) = { command with UserId = userId }
+    static member WithUserId userId (command:SetRisk) = { command with UserId = userId }
     
 type SimulateTrade = 
     {

--- a/src/core.fs/Portfolio/Handler.fs
+++ b/src/core.fs/Portfolio/Handler.fs
@@ -13,17 +13,18 @@ open core.Stocks
 open core.Stocks.Services.Trading
 open core.fs.Shared
 open core.fs.Shared.Adapters.Storage
+open core.fs.Shared.Domain.Accounts
 
 type Query =
     {
-        UserId: Guid
+        UserId: UserId
     }
     
 type DeletePosition =
     {
         PositionId: int
         Ticker: Ticker
-        UserId: Guid
+        UserId: UserId
     }
 
 type GradePosition =
@@ -32,20 +33,20 @@ type GradePosition =
         PositionId: int
         [<Required>]
         Ticker: Ticker
-        UserId: Guid
+        UserId: UserId
         [<Required>]
         Grade: TradeGrade
         Note: string
     }
     
-    static member WithUserId (userId:Guid) (command:GradePosition) = { command with UserId = userId }
+    static member WithUserId (userId:UserId) (command:GradePosition) = { command with UserId = userId }
     
 type RemoveLabel =
     {
         PositionId: int
         [<Required>]
         Ticker: Ticker
-        UserId: Guid
+        UserId: UserId
         [<Required>]
         Key: string
     }
@@ -56,14 +57,14 @@ type AddLabel =
         PositionId: int
         [<Required>]
         Ticker: Ticker
-        UserId: Guid
+        UserId: UserId
         [<Required>]
         Key: string
         [<Required>]
         Value: string
     }
     
-    static member WithUserId (userId:Guid) (command:AddLabel) = { command with UserId = userId }
+    static member WithUserId (userId:UserId) (command:AddLabel) = { command with UserId = userId }
     
 type ProfitPointsQuery =
     {
@@ -71,7 +72,7 @@ type ProfitPointsQuery =
         PositionId: int
         [<Required>]
         Ticker: Ticker
-        UserId: Guid
+        UserId: UserId
     }
     
 type SetRisk =
@@ -80,17 +81,17 @@ type SetRisk =
         PositionId: int
         [<Required>]
         Ticker: Ticker
-        UserId: Guid
+        UserId: UserId
         [<Required>]
         RiskAmount: Nullable<decimal>
     }
-    static member WithUserId (userId:Guid) (command:SetRisk) = { command with UserId = userId }
+    static member WithUserId (userId:UserId) (command:SetRisk) = { command with UserId = userId }
     
 type SimulateTrade = 
     {
         [<Required>]
         Ticker: Ticker
-        UserId: Guid
+        UserId: UserId
         [<Required>]
         PositionId: int
     }
@@ -102,36 +103,36 @@ type SimulateTradeForTicker =
         Price: decimal
         StopPrice: decimal
         Ticker: Ticker
-        UserId: Guid
+        UserId: UserId
     }
     
 type SimulateUserTrades =
     {
-        UserId: Guid
+        UserId: UserId
         NumberOfTrades: int
         ClosePositionIfOpenAtTheEnd: bool
     }
     
 type ExportUserSimulatedTrades =
     {
-        UserId: Guid
+        UserId: UserId
         NumberOfTrades: int
         ClosePositionIfOpenAtTheEnd: bool
     }
 
 type QueryTradingEntries =
     {
-        UserId: Guid
+        UserId: UserId
     }
     
 type QueryPastTradingEntries =
     {
-        UserId: Guid
+        UserId: UserId
     }
     
 type QueryTransactions =
     {
-        UserId: Guid
+        UserId: UserId
         Show:string
         GroupBy:string
         TxType:string
@@ -141,7 +142,7 @@ type QueryTransactions =
 type TransactionSummary =
     {
         Period: string
-        UserId: Guid
+        UserId: UserId
     }
     
     member this.GetDates() =

--- a/src/core.fs/Portfolio/ListsHandler.fs
+++ b/src/core.fs/Portfolio/ListsHandler.fs
@@ -7,23 +7,24 @@ open core.Shared
 open core.Shared.Adapters.CSV
 open core.fs.Shared
 open core.fs.Shared.Adapters.Storage
+open core.fs.Shared.Domain.Accounts
 
 
 type GetLists =
     {
-        UserId:Guid
+        UserId:UserId
     }
 
 type GetList =
     {
         Name: string
-        UserId: Guid
+        UserId: UserId
     }
     
 type ExportList =
     {
         Name: string
-        UserId: Guid
+        UserId: UserId
         JustTickers: bool
     }
     
@@ -31,17 +32,17 @@ type AddStockToList =
     {
         [<Required>]
         Name: string
-        UserId: Guid
+        UserId: UserId
         [<Required>]
         Ticker: Ticker
     }
-    static member WithUserId (userId:Guid) (command:AddStockToList) = { command with UserId = userId }
+    static member WithUserId (userId:UserId) (command:AddStockToList) = { command with UserId = userId }
     
 type RemoveStockFromList =
     {
         [<Required>]
         Name: string
-        UserId: Guid
+        UserId: UserId
         [<Required>]
         Ticker: Ticker
     }
@@ -54,9 +55,9 @@ type AddTagToList =
         Tag: string
         [<Required>]
         Name: string
-        UserId: Guid
+        UserId: UserId
     }
-    static member WithUserId (userId:Guid) (command:AddTagToList) = { command with UserId = userId }
+    static member WithUserId (userId:UserId) (command:AddTagToList) = { command with UserId = userId }
     
 type RemoveTagFromList =
     {
@@ -64,29 +65,29 @@ type RemoveTagFromList =
         Tag: string
         [<Required>]
         Name: string
-        UserId: Guid
+        UserId: UserId
     }
     
 type Create =
     {
         Name: string
         Description: string
-        UserId: Guid
+        UserId: UserId
     }
-    static member WithUserId (userId:Guid) (command:Create) = { command with UserId = userId }
+    static member WithUserId (userId:UserId) (command:Create) = { command with UserId = userId }
     
 type Update =
     {
         Name: string
         Description: string
-        UserId: Guid
+        UserId: UserId
     }
-    static member WithUserId (userId:Guid) (command:Update) = { command with UserId = userId }
+    static member WithUserId (userId:UserId) (command:Update) = { command with UserId = userId }
     
 type Delete =
     {
         Name: string
-        UserId: Guid
+        UserId: UserId
     }
     
 type Handler(accounts:IAccountStorage, portfolio:IPortfolioStorage, csvWriter:ICSVWriter) =
@@ -199,7 +200,7 @@ type Handler(accounts:IAccountStorage, portfolio:IPortfolioStorage, csvWriter:IC
             let! list = portfolio.GetStockList command.Name command.UserId
             match list with
             | null ->
-                let newList = StockList(name=command.Name, description=command.Description, userId=command.UserId)
+                let newList = StockList(name=command.Name, description=command.Description, userId=(command.UserId |> IdentifierHelper.getUserId))
                 do! portfolio.SaveStockList newList command.UserId
                 return newList.State |> ResponseUtils.success
             | _ ->

--- a/src/core.fs/Portfolio/ListsHandler.fs
+++ b/src/core.fs/Portfolio/ListsHandler.fs
@@ -1,6 +1,5 @@
 namespace core.fs.Portfolio.Lists
 
-open System
 open System.ComponentModel.DataAnnotations
 open core.Portfolio
 open core.Shared
@@ -36,7 +35,7 @@ type AddStockToList =
         [<Required>]
         Ticker: Ticker
     }
-    static member WithUserId (userId:UserId) (command:AddStockToList) = { command with UserId = userId }
+    static member WithUserId userId (command:AddStockToList) = { command with UserId = userId }
     
 type RemoveStockFromList =
     {
@@ -57,7 +56,7 @@ type AddTagToList =
         Name: string
         UserId: UserId
     }
-    static member WithUserId (userId:UserId) (command:AddTagToList) = { command with UserId = userId }
+    static member WithUserId userId (command:AddTagToList) = { command with UserId = userId }
     
 type RemoveTagFromList =
     {
@@ -74,7 +73,7 @@ type Create =
         Description: string
         UserId: UserId
     }
-    static member WithUserId (userId:UserId) (command:Create) = { command with UserId = userId }
+    static member WithUserId userId (command:Create) = { command with UserId = userId }
     
 type Update =
     {
@@ -82,7 +81,7 @@ type Update =
         Description: string
         UserId: UserId
     }
-    static member WithUserId (userId:UserId) (command:Update) = { command with UserId = userId }
+    static member WithUserId userId (command:Update) = { command with UserId = userId }
     
 type Delete =
     {

--- a/src/core.fs/Portfolio/PendingPositionsHandler.fs
+++ b/src/core.fs/Portfolio/PendingPositionsHandler.fs
@@ -32,7 +32,7 @@ type Create =
         UserId: UserId
     }
     
-    static member WithUserId (userId:UserId) (command:Create) =
+    static member WithUserId userId (command:Create) =
         { command with UserId = userId }
         
 type Close =

--- a/src/core.fs/Portfolio/PendingPositionsHandler.fs
+++ b/src/core.fs/Portfolio/PendingPositionsHandler.fs
@@ -9,6 +9,7 @@ open core.Shared.Adapters.Brokerage
 open core.Shared.Adapters.CSV
 open core.fs.Shared
 open core.fs.Shared.Adapters.Storage
+open core.fs.Shared.Domain.Accounts
 
 [<CLIMutable>]
 [<Struct>]
@@ -28,27 +29,27 @@ type Create =
         Ticker: Ticker
         [<Required(AllowEmptyStrings = false)>]
         Strategy: string
-        UserId: Guid
+        UserId: UserId
     }
     
-    static member WithUserId (userId:Guid) (command:Create) =
+    static member WithUserId (userId:UserId) (command:Create) =
         { command with UserId = userId }
         
 type Close =
     {
         [<Required>]
         PositionId: Guid
-        UserId: Guid
+        UserId: UserId
     }
     
 type Export =
     {
-        UserId: Guid
+        UserId: UserId
     }
     
 type Query =
     {
-        UserId: Guid
+        UserId: UserId
     }
 
 type Handler(accounts:IAccountStorage,brokerage:IBrokerage,portfolio:IPortfolioStorage,csvWriter:ICSVWriter) =
@@ -90,7 +91,7 @@ type Handler(accounts:IAccountStorage,brokerage:IBrokerage,portfolio:IPortfolioS
                         stopPrice=command.StopPrice,
                         strategy=command.Strategy,
                         ticker=command.Ticker,
-                        userId=command.UserId
+                        userId=(command.UserId |> IdentifierHelper.getUserId)
                     )
                     
                     do! portfolio.SavePendingPosition position command.UserId
@@ -138,9 +139,9 @@ type Handler(accounts:IAccountStorage,brokerage:IBrokerage,portfolio:IPortfolioS
         
         match user with
         | None -> return "User not found" |> ResponseUtils.failedTyped<ExportResponse>
-        | Some user ->
+        | Some _ ->
             
-            let! positions = portfolio.GetPendingStockPositions(user.Id)
+            let! positions = portfolio.GetPendingStockPositions(command.UserId)
             
             let data = positions |> Seq.sortByDescending(fun x -> x.State.Date);
                 

--- a/src/core.fs/Portfolio/RoutinesHandler.fs
+++ b/src/core.fs/Portfolio/RoutinesHandler.fs
@@ -20,7 +20,7 @@ type Create =
         Description:string
     }
     
-    static member WithUserId (userId:UserId) (create:Create) =
+    static member WithUserId userId (create:Create) =
         { create with UserId = userId }
     
 type Update =
@@ -33,7 +33,7 @@ type Update =
         Description:string
     }
     
-    static member WithUserId (userId:UserId) (update:Update) =
+    static member WithUserId userId (update:Update) =
         { update with UserId = userId }
     
 type Delete =
@@ -51,7 +51,7 @@ type AddStep =
         Label:string
         Url:string
     }
-    static member WithUserId (userId:UserId) (add:AddStep) =
+    static member WithUserId userId (add:AddStep) =
         { add with UserId = userId }
 
 type MoveStep =
@@ -64,7 +64,7 @@ type MoveStep =
         Direction:Nullable<int>
         UserId:UserId
     }
-    static member WithUserId (userId:UserId) (move:MoveStep) =
+    static member WithUserId userId (move:MoveStep) =
         { move with UserId = userId }
     
 type RemoveStep =
@@ -88,7 +88,7 @@ type UpdateStep =
         UserId:UserId
     }
     
-    static member WithUserId (userId:UserId) (update:UpdateStep) =
+    static member WithUserId userId (update:UpdateStep) =
         { update with UserId = userId }
     
 type Handler(accounts:IAccountStorage,storage:IPortfolioStorage) =

--- a/src/core.fs/Portfolio/RoutinesHandler.fs
+++ b/src/core.fs/Portfolio/RoutinesHandler.fs
@@ -6,25 +6,26 @@ open core.Portfolio
 open core.Shared
 open core.fs.Shared
 open core.fs.Shared.Adapters.Storage
+open core.fs.Shared.Domain.Accounts
 
 type Query =
     {
-        UserId:Guid
+        UserId:UserId
     }
     
 type Create =
     {
-        UserId:Guid
+        UserId:UserId
         Name:string
         Description:string
     }
     
-    static member WithUserId (userId:Guid) (create:Create) =
+    static member WithUserId (userId:UserId) (create:Create) =
         { create with UserId = userId }
     
 type Update =
     {
-        UserId:Guid
+        UserId:UserId
         [<Required>]
         Name:string
         [<Required>]
@@ -32,25 +33,25 @@ type Update =
         Description:string
     }
     
-    static member WithUserId (userId:Guid) (update:Update) =
+    static member WithUserId (userId:UserId) (update:Update) =
         { update with UserId = userId }
     
 type Delete =
     {
-        UserId:Guid
+        UserId:UserId
         Name:string
     }
     
 type AddStep =
     {
-        UserId:Guid
+        UserId:UserId
         [<Required>]
         RoutineName:string
         [<Required>]
         Label:string
         Url:string
     }
-    static member WithUserId (userId:Guid) (add:AddStep) =
+    static member WithUserId (userId:UserId) (add:AddStep) =
         { add with UserId = userId }
 
 type MoveStep =
@@ -61,9 +62,9 @@ type MoveStep =
         StepIndex:Nullable<int>
         [<Required>]
         Direction:Nullable<int>
-        UserId:Guid
+        UserId:UserId
     }
-    static member WithUserId (userId:Guid) (move:MoveStep) =
+    static member WithUserId (userId:UserId) (move:MoveStep) =
         { move with UserId = userId }
     
 type RemoveStep =
@@ -72,7 +73,7 @@ type RemoveStep =
         RoutineName: string
         [<Required>]
         StepIndex:Nullable<int>
-        UserId:Guid
+        UserId:UserId
     }
     
 type UpdateStep =
@@ -84,10 +85,10 @@ type UpdateStep =
         [<Required>]
         Label:string
         Url:string
-        UserId:Guid
+        UserId:UserId
     }
     
-    static member WithUserId (userId:Guid) (update:UpdateStep) =
+    static member WithUserId (userId:UserId) (update:UpdateStep) =
         { update with UserId = userId }
     
 type Handler(accounts:IAccountStorage,storage:IPortfolioStorage) =
@@ -103,7 +104,7 @@ type Handler(accounts:IAccountStorage,storage:IPortfolioStorage) =
             let! routine = storage.GetRoutine create.Name create.UserId
             match routine with
             | null ->
-                let routine = Routine(name=create.Name,description=create.Description,userId=create.UserId)
+                let routine = Routine(name=create.Name,description=create.Description,userId=(create.UserId |> IdentifierHelper.getUserId))
                 do! storage.SaveRoutine routine create.UserId
                 return ServiceResponse<RoutineState>(routine.State)
             | _ -> return "Routine already exists" |> ResponseUtils.failedTyped<RoutineState>

--- a/src/core.fs/Reports/Handlers.fs
+++ b/src/core.fs/Reports/Handlers.fs
@@ -10,10 +10,11 @@ open core.Stocks
 open core.Stocks.Services.Analysis
 open core.fs.Shared
 open core.fs.Shared.Adapters.Storage
+open core.fs.Shared.Domain.Accounts
 
 type ChainQuery =
     {
-        UserId: Guid
+        UserId: UserId
     }
     
 type ChainLinkView = 
@@ -31,7 +32,7 @@ type ChainView =
     
 type DailyOutcomeScoreReportQuery =
     {
-        UserId: Guid
+        UserId: UserId
         Start: string
         End: string
         Ticker: Ticker
@@ -45,7 +46,7 @@ type DailyOutcomeScoreReportView =
     
 type DailyPositionReportQuery =
     {
-        UserId: Guid
+        UserId: UserId
         Ticker: string
         PositionId: int
     }
@@ -59,7 +60,7 @@ type DailyPositionReportView =
     
 type GapReportQuery =
     {
-        UserId: Guid
+        UserId: UserId
         Ticker: string
         Frequency: PriceFrequency
     }
@@ -78,7 +79,7 @@ type OutcomesReportQuery =
     {
         [<Required>]
         Tickers: string[]
-        UserId: Guid
+        UserId: UserId
         [<Required>]
         Duration: OutcomesReportDuration
         [<Required>]
@@ -88,12 +89,12 @@ type OutcomesReportQuery =
         EndDate: string
     }
     
-    static member WithUserId (userId:Guid) (query:OutcomesReportQuery) =
+    static member WithUserId (userId:UserId) (query:OutcomesReportQuery) =
         {query with UserId=userId}
     
 type OutcomesReportForPositionsQuery =
     {
-        UserId: Guid
+        UserId: UserId
     }
 
 type OutcomesReportViewTickerCountPair =
@@ -137,7 +138,7 @@ type PercentChangeStatisticsQuery =
     {
         Frequency: PriceFrequency
         Ticker: string
-        UserId: Guid
+        UserId: UserId
     }
     
 type PercentChangeStatisticsView =
@@ -149,7 +150,7 @@ type PercentChangeStatisticsView =
     
 type SellsQuery =
     {
-        UserId: Guid
+        UserId: UserId
     }
     
 type SellView =

--- a/src/core.fs/Reports/Handlers.fs
+++ b/src/core.fs/Reports/Handlers.fs
@@ -89,7 +89,7 @@ type OutcomesReportQuery =
         EndDate: string
     }
     
-    static member WithUserId (userId:UserId) (query:OutcomesReportQuery) =
+    static member WithUserId userId (query:OutcomesReportQuery) =
         {query with UserId=userId}
     
 type OutcomesReportForPositionsQuery =

--- a/src/core.fs/Shared/Adapters/Storage/IAccountStorage.fs
+++ b/src/core.fs/Shared/Adapters/Storage/IAccountStorage.fs
@@ -9,7 +9,7 @@ open core.fs.Shared.Domain.Accounts
 type IAccountStorage =
     
     abstract member GetUserByEmail: emailAddress:string -> Task<User option>
-    abstract member GetUser: userId:Guid -> Task<User option>
+    abstract member GetUser: userId:UserId -> Task<User option>
     abstract member Save: u:User -> Task
     abstract member Delete: u:User -> Task
     abstract member SaveUserAssociation: r:ProcessIdToUserAssociation -> Task

--- a/src/core.fs/Shared/Adapters/Storage/IPortfolioStorage.fs
+++ b/src/core.fs/Shared/Adapters/Storage/IPortfolioStorage.fs
@@ -7,38 +7,39 @@ open core.Notes
 open core.Options
 open core.Portfolio
 open core.Stocks
+open core.fs.Shared.Domain.Accounts
 
 type IPortfolioStorage =
     
-    abstract member GetStock : ticker:string -> userId:System.Guid -> Task<OwnedStock>
-    abstract member GetStockByStockId : id:System.Guid -> userId:System.Guid -> Task<OwnedStock>
-    abstract member GetStocks : userId:System.Guid -> Task<IEnumerable<OwnedStock>>
-    abstract member Save : stock:OwnedStock -> userId:System.Guid -> Task
+    abstract member GetStock : ticker:string -> userId:UserId -> Task<OwnedStock>
+    abstract member GetStockByStockId : id:System.Guid -> userId:UserId -> Task<OwnedStock>
+    abstract member GetStocks : userId:UserId -> Task<IEnumerable<OwnedStock>>
+    abstract member Save : stock:OwnedStock -> userId:UserId -> Task
     
-    abstract member Delete : userId:System.Guid -> Task
+    abstract member Delete : userId:UserId -> Task
     
-    abstract member GetStockList : name:string -> userId:System.Guid -> Task<StockList>
-    abstract member GetStockLists : userId:System.Guid -> Task<IEnumerable<StockList>>
-    abstract member SaveStockList : list:StockList -> userId:System.Guid -> Task
-    abstract member DeleteStockList : list:StockList -> userId:System.Guid -> Task
+    abstract member GetStockList : name:string -> userId:UserId -> Task<StockList>
+    abstract member GetStockLists : userId:UserId -> Task<IEnumerable<StockList>>
+    abstract member SaveStockList : list:StockList -> userId:UserId -> Task
+    abstract member DeleteStockList : list:StockList -> userId:UserId -> Task
     
-    abstract member SavePendingPosition : position:PendingStockPosition -> userId:System.Guid -> Task
-    abstract member GetPendingStockPositions : userId:System.Guid -> Task<IEnumerable<PendingStockPosition>>
+    abstract member SavePendingPosition : position:PendingStockPosition -> userId:UserId -> Task
+    abstract member GetPendingStockPositions : userId:UserId -> Task<IEnumerable<PendingStockPosition>>
     
-    abstract member GetRoutines : userId:System.Guid -> Task<IEnumerable<Routine>>
-    abstract member GetRoutine : name:string -> userId:System.Guid -> Task<Routine>
-    abstract member SaveRoutine : routine:Routine -> userId:System.Guid -> Task
-    abstract member DeleteRoutine : routine:Routine -> userId:System.Guid -> Task
+    abstract member GetRoutines : userId:UserId -> Task<IEnumerable<Routine>>
+    abstract member GetRoutine : name:string -> userId:UserId -> Task<Routine>
+    abstract member SaveRoutine : routine:Routine -> userId:UserId -> Task
+    abstract member DeleteRoutine : routine:Routine -> userId:UserId -> Task
     
-    abstract member GetOwnedOptions : userId:System.Guid -> Task<IEnumerable<OwnedOption>>
-    abstract member GetOwnedOption : optionId:System.Guid -> userId:System.Guid -> Task<OwnedOption>
-    abstract member SaveOwnedOption : option:OwnedOption -> userId:System.Guid -> Task
+    abstract member GetOwnedOptions : userId:UserId -> Task<IEnumerable<OwnedOption>>
+    abstract member GetOwnedOption : optionId:System.Guid -> userId:UserId -> Task<OwnedOption>
+    abstract member SaveOwnedOption : option:OwnedOption -> userId:UserId -> Task
     
-    abstract member GetNotes : userId:System.Guid -> Task<IEnumerable<Note>>
-    abstract member GetNote : noteId:System.Guid -> userId:System.Guid -> Task<Note>
-    abstract member SaveNote : note:Note -> userId:System.Guid -> Task
+    abstract member GetNotes : userId:UserId -> Task<IEnumerable<Note>>
+    abstract member GetNote : noteId:System.Guid -> userId:UserId -> Task<Note>
+    abstract member SaveNote : note:Note -> userId:UserId -> Task
     
-    abstract member GetCrypto : token:string -> userId:System.Guid -> Task<OwnedCrypto>
-    abstract member GetCryptoByCryptoId : id:System.Guid -> userId:System.Guid -> Task<OwnedCrypto>
-    abstract member GetCryptos : userId:System.Guid -> Task<IEnumerable<OwnedCrypto>>
-    abstract member SaveCrypto : crypto:OwnedCrypto -> userId:System.Guid -> Task
+    abstract member GetCrypto : token:string -> userId:UserId -> Task<OwnedCrypto>
+    abstract member GetCryptoByCryptoId : id:System.Guid -> userId:UserId -> Task<OwnedCrypto>
+    abstract member GetCryptos : userId:UserId -> Task<IEnumerable<OwnedCrypto>>
+    abstract member SaveCrypto : crypto:OwnedCrypto -> userId:UserId -> Task

--- a/src/core.fs/Shared/Domain/Accounts/Types.fs
+++ b/src/core.fs/Shared/Domain/Accounts/Types.fs
@@ -2,18 +2,26 @@
 
 open System
 
+type UserId = UserId of Guid
+
+module IdentifierHelper =
+    
+    let getUserId (userId:UserId) =
+        match userId with
+        | UserId id -> id
+    
 [<Struct>]
-type EmailIdPair(email:string, id:string) =
+type EmailIdPair(email:string, id:UserId) =
     
     member _.Email = email
     member _.Id = id
     
    
-type ProcessIdToUserAssociation(Id:Guid, UserId:Guid, Timestamp:DateTimeOffset) =
+type ProcessIdToUserAssociation(Id:Guid, UserId:UserId, Timestamp:DateTimeOffset) =
     
-    new(userId:Guid, timestamp:DateTimeOffset) = ProcessIdToUserAssociation(Guid.NewGuid(), userId, timestamp)
-    new(userId:Guid, timestamp:string) = ProcessIdToUserAssociation(Guid.NewGuid(), userId, DateTimeOffset.Parse(timestamp))
-    new(id:Guid, userId:Guid, timestamp:string) = ProcessIdToUserAssociation(id, userId, DateTimeOffset.Parse(timestamp))
+    new(userId:UserId, timestamp:DateTimeOffset) = ProcessIdToUserAssociation(Guid.NewGuid(), userId, timestamp)
+    new(userId:UserId, timestamp:string) = ProcessIdToUserAssociation(Guid.NewGuid(), userId, DateTimeOffset.Parse(timestamp))
+    new(id:Guid, userId:Guid, timestamp:string) = ProcessIdToUserAssociation(id, userId |> UserId, DateTimeOffset.Parse(timestamp))
     
     member _.IsOlderThan(duration:TimeSpan) = DateTimeOffset.UtcNow.Subtract(Timestamp) > duration
     member _.Id = Id

--- a/src/core.fs/Shared/Domain/Accounts/Types.fs
+++ b/src/core.fs/Shared/Domain/Accounts/Types.fs
@@ -6,7 +6,7 @@ type UserId = UserId of Guid
 
 module IdentifierHelper =
     
-    let getUserId (userId:UserId) =
+    let getUserId userId =
         match userId with
         | UserId id -> id
     
@@ -19,8 +19,8 @@ type EmailIdPair(email:string, id:UserId) =
    
 type ProcessIdToUserAssociation(Id:Guid, UserId:UserId, Timestamp:DateTimeOffset) =
     
-    new(userId:UserId, timestamp:DateTimeOffset) = ProcessIdToUserAssociation(Guid.NewGuid(), userId, timestamp)
-    new(userId:UserId, timestamp:string) = ProcessIdToUserAssociation(Guid.NewGuid(), userId, DateTimeOffset.Parse(timestamp))
+    new(userId, timestamp:DateTimeOffset) = ProcessIdToUserAssociation(Guid.NewGuid(), userId, timestamp)
+    new(userId, timestamp:string) = ProcessIdToUserAssociation(Guid.NewGuid(), userId, DateTimeOffset.Parse(timestamp))
     new(id:Guid, userId:Guid, timestamp:string) = ProcessIdToUserAssociation(id, userId |> UserId, DateTimeOffset.Parse(timestamp))
     
     member _.IsOlderThan(duration:TimeSpan) = DateTimeOffset.UtcNow.Subtract(Timestamp) > duration

--- a/src/core.fs/Stocks/Handlers.fs
+++ b/src/core.fs/Stocks/Handlers.fs
@@ -13,6 +13,7 @@ open core.Stocks.Services
 open core.Stocks.Services.Analysis
 open core.fs.Shared
 open core.fs.Shared.Adapters.Storage
+open core.fs.Shared.Domain.Accounts
 
 
 type StockTransaction =
@@ -31,12 +32,12 @@ type StockTransaction =
     }
     
 type BuyOrSell =
-    | Buy of StockTransaction * Guid
-    | Sell of StockTransaction * Guid
+    | Buy of StockTransaction * UserId
+    | Sell of StockTransaction * UserId
     
 type DashboardQuery =
     {
-        UserId: Guid
+        UserId: UserId
     }
     
 type DashboardView =
@@ -48,26 +49,26 @@ type DashboardView =
 type DeleteStock =
     {
         StockId: Guid
-        UserId: Guid
+        UserId: UserId
     }
     
 type DeleteStop =
     {
         Ticker: Ticker
-        UserId: Guid
+        UserId: UserId
     }
     
 type DeleteTransaction =
     {
         Ticker: Ticker
-        UserId: Guid
+        UserId: UserId
         TransactionId: Guid
     }
     
 type DetailsQuery =
     {
         Ticker: Ticker
-        UserId: Guid
+        UserId: UserId
     }
     
 type DetailsView =
@@ -83,18 +84,18 @@ type ExportType =
     
 type ExportTrades =
     {
-        UserId: Guid
+        UserId: UserId
         ExportType: ExportType
     }
 
 type ExportTransactions =
     {
-        UserId: Guid
+        UserId: UserId
     }
     
 type ImportStocks =
     {
-        UserId: Guid
+        UserId: UserId
         Content: string
     }
 
@@ -110,7 +111,7 @@ type private ImportRecord =
 type OwnershipQuery =
     {
         Ticker: Ticker
-        UserId: Guid
+        UserId: UserId
     }
     
 type OwnershipView =
@@ -123,13 +124,13 @@ type OwnershipView =
     
 type PriceQuery =
     {
-        UserId:Guid
+        UserId:UserId
         Ticker:Ticker
     }
     
 type PricesQuery =
     {
-        UserId:Guid
+        UserId:UserId
         Ticker:Ticker
         Start:DateTimeOffset
         End:DateTimeOffset
@@ -155,19 +156,19 @@ type PricesView(prices:PriceBar array) =
 type QuoteQuery =
     {
         Ticker:Ticker
-        UserId:Guid
+        UserId:UserId
     }
     
 type SearchQuery =
     {
         Term:string
-        UserId:Guid
+        UserId:UserId
     }
     
 type CompanyFilingsQuery =
     {
         Ticker:Ticker
-        UserId:Guid
+        UserId:UserId
     }
     
 type SetStop =
@@ -175,7 +176,7 @@ type SetStop =
         [<Required>]
         StopPrice:Nullable<decimal>
         Ticker:Ticker
-        UserId:Guid
+        UserId:UserId
     }
     
     static member WithUserId userId (cmd:SetStop) =
@@ -206,7 +207,7 @@ type Handler(accounts:IAccountStorage,brokerage:IBrokerage,secFilings:ISECFiling
             
             let stockToUse =
                 match stock with
-                | null -> OwnedStock(ticker=data.Ticker, userId=userId)
+                | null -> OwnedStock(ticker=data.Ticker, userId=(userId |> IdentifierHelper.getUserId))
                 | _ -> stock
                 
             let isNewPosition = stockToUse.State.OpenPosition = null

--- a/src/infrastructure/storage.memory/AccountStorage.cs
+++ b/src/infrastructure/storage.memory/AccountStorage.cs
@@ -21,9 +21,9 @@ public class AccountStorage : MemoryAggregateStorage, IAccountStorage
         return Task.CompletedTask;
     }
 
-    public Task<FSharpOption<User>> GetUser(Guid userId)
+    public Task<FSharpOption<User>> GetUser(UserId userId)
     {
-        var response = _users.TryGetValue(userId, out var u) ? new FSharpOption<User>(u!) : FSharpOption<User>.None;
+        var response = _users.TryGetValue(userId.Item, out var u) ? new FSharpOption<User>(u!) : FSharpOption<User>.None;
         
         return Task.FromResult(response);
     }
@@ -43,7 +43,7 @@ public class AccountStorage : MemoryAggregateStorage, IAccountStorage
 
     public Task<IEnumerable<EmailIdPair>> GetUserEmailIdPairs() =>
         Task.FromResult(
-            _users.Values.Where(u => u != null).Select(u => new EmailIdPair(email: u!.State.Email, id: u.Id.ToString()))
+            _users.Values.Where(u => u != null).Select(u => new EmailIdPair(email: u!.State.Email, id: UserId.NewUserId(u.Id)))
         );
 
     public async Task Save(User u)

--- a/src/infrastructure/storage.postgres/AccountStorage.cs
+++ b/src/infrastructure/storage.postgres/AccountStorage.cs
@@ -18,9 +18,9 @@ namespace storage.postgres
         {
         }
 
-        public async Task<FSharpOption<User>> GetUser(Guid userId)
+        public async Task<FSharpOption<User>> GetUser(UserId userId)
         {
-            var events = await GetEventsAsync(_user_entity, userId);
+            var events = await GetEventsAsync(_user_entity, userId.Item);
 
             var u = new User(events);
             return u.Id == Guid.Empty ? FSharpOption<User>.None : new FSharpOption<User>(u);
@@ -43,7 +43,7 @@ namespace storage.postgres
                 return FSharpOption<User>.None;
             }
 
-            return await GetUser(new Guid(identifier));
+            return await GetUser(UserId.NewUserId(new Guid(identifier)));
         }
 
         public async Task Save(User u)

--- a/src/infrastructure/storage.shared/PortfolioStorage.cs
+++ b/src/infrastructure/storage.shared/PortfolioStorage.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using core.Cryptos;
 using core.fs.Shared.Adapters.Storage;
+using core.fs.Shared.Domain.Accounts;
 using core.Notes;
 using core.Options;
 using core.Portfolio;
@@ -43,161 +44,161 @@ namespace storage.shared
             return _blobStorage.Save(typeof(T).Name + "#" + version + "#" + userId, t);
         }
 
-        public async Task<OwnedStock> GetStock(string ticker, Guid userId)
+        public async Task<OwnedStock> GetStock(string ticker, UserId userId)
         {
             var stocks = await GetStocks(userId);
             
             return stocks.SingleOrDefault(s => s.State.Ticker == ticker);
         }
 
-        public async Task<OwnedStock> GetStockByStockId(Guid stockId, Guid userId)
+        public async Task<OwnedStock> GetStockByStockId(Guid stockId, UserId userId)
         {
             var stocks = await GetStocks(userId);
             
             return stocks.SingleOrDefault(s => s.Id == stockId);
         }
 
-        public Task Save(OwnedStock stock, Guid userId)
+        public Task Save(OwnedStock stock, UserId userId)
         {
             return Save(stock, _stock_entity, userId);
         }
 
-        public Task SaveOwnedOption(OwnedOption option, Guid userId)
+        public Task SaveOwnedOption(OwnedOption option, UserId userId)
         {
             return Save(option, _option_entity, userId);
         }
 
-        private Task Save(Aggregate agg, string entityName, Guid userId)
+        private Task Save(Aggregate agg, string entityName, UserId userId)
         {
-            return _aggregateStorage.SaveEventsAsync(agg, entityName, userId);
+            return _aggregateStorage.SaveEventsAsync(agg, entityName, userId.Item);
         }
 
-        public async Task<IEnumerable<OwnedStock>> GetStocks(Guid userId)
+        public async Task<IEnumerable<OwnedStock>> GetStocks(UserId userId)
         {
-            var list = await _aggregateStorage.GetEventsAsync(_stock_entity, userId);
+            var list = await _aggregateStorage.GetEventsAsync(_stock_entity, userId.Item);
 
             return list.GroupBy(e => e.AggregateId)
                 .Select(g => new OwnedStock(g));
         }
 
-        public async Task<OwnedOption> GetOwnedOption(Guid optionId, Guid userId)
+        public async Task<OwnedOption> GetOwnedOption(Guid optionId, UserId userId)
         {
             return (await GetOwnedOptions(userId)).SingleOrDefault(s => s.State.Id == optionId);
         }
 
-        public async Task<IEnumerable<OwnedOption>> GetOwnedOptions(Guid userId)
+        public async Task<IEnumerable<OwnedOption>> GetOwnedOptions(UserId userId)
         {
-            var list = await _aggregateStorage.GetEventsAsync(_option_entity, userId);
+            var list = await _aggregateStorage.GetEventsAsync(_option_entity, userId.Item);
 
             return list.GroupBy(e => e.AggregateId)
                 .Select(g => new OwnedOption(g))
                 .Where(g => g.State.Deleted == false);
         }
 
-        public Task SaveNote(Note note, Guid userId)
+        public Task SaveNote(Note note, UserId userId)
         {
             return Save(note, _note_entity, userId);
         }
 
-        public async Task<IEnumerable<Note>> GetNotes(Guid userId)
+        public async Task<IEnumerable<Note>> GetNotes(UserId userId)
         {
-            var list = await _aggregateStorage.GetEventsAsync(_note_entity, userId);
+            var list = await _aggregateStorage.GetEventsAsync(_note_entity, userId.Item);
 
             return list.GroupBy(e => e.AggregateId)
                 .Select(g => new Note(g));
         }
 
-        public async Task<Note> GetNote(Guid userId, Guid noteId)
+        public async Task<Note> GetNote(Guid noteId, UserId userId)
         {
             var list = await GetNotes(userId);
 
             return list.SingleOrDefault(n => n.State.Id == noteId);
         }
 
-        public async Task Delete(Guid userId)
+        public async Task Delete(UserId userId)
         {
-            await _aggregateStorage.DeleteAggregates(_note_entity, userId);
-            await _aggregateStorage.DeleteAggregates(_option_entity, userId);
-            await _aggregateStorage.DeleteAggregates(_stock_entity, userId);
-            await _aggregateStorage.DeleteAggregates(_crypto_entity, userId);
-            await _aggregateStorage.DeleteAggregates(_stock_list_entity, userId);
-            await _aggregateStorage.DeleteAggregates(_pending_stock_position_entity, userId);
+            await _aggregateStorage.DeleteAggregates(_note_entity, userId.Item);
+            await _aggregateStorage.DeleteAggregates(_option_entity, userId.Item);
+            await _aggregateStorage.DeleteAggregates(_stock_entity, userId.Item);
+            await _aggregateStorage.DeleteAggregates(_crypto_entity, userId.Item);
+            await _aggregateStorage.DeleteAggregates(_stock_list_entity, userId.Item);
+            await _aggregateStorage.DeleteAggregates(_pending_stock_position_entity, userId.Item);
         }
 
-        public async Task<OwnedCrypto> GetCrypto(string token, Guid userId)
+        public async Task<OwnedCrypto> GetCrypto(string token, UserId userId)
         {
             var cryptos = await GetCryptos(userId);
             
             return cryptos.SingleOrDefault(s => s.State.Token == token);
         }
 
-        public async Task<OwnedCrypto> GetCryptoByCryptoId(Guid cryptoId, Guid userId)
+        public async Task<OwnedCrypto> GetCryptoByCryptoId(Guid cryptoId, UserId userId)
         {
             var cryptos = await GetCryptos(userId);
             
             return cryptos.SingleOrDefault(s => s.Id == cryptoId);
         }
 
-        public Task SaveCrypto(OwnedCrypto crypto, Guid userId)
+        public Task SaveCrypto(OwnedCrypto crypto, UserId userId)
         {
             return Save(crypto, _crypto_entity, userId);
         }
 
-        public async Task<IEnumerable<OwnedCrypto>> GetCryptos(Guid userId)
+        public async Task<IEnumerable<OwnedCrypto>> GetCryptos(UserId userId)
         {
-            var list = await _aggregateStorage.GetEventsAsync(_crypto_entity, userId);
+            var list = await _aggregateStorage.GetEventsAsync(_crypto_entity, userId.Item);
 
             return list.GroupBy(e => e.AggregateId)
                 .Select(g => new OwnedCrypto(g));
         }
 
-        public async Task<IEnumerable<Routine>> GetRoutines(Guid userId)
+        public async Task<IEnumerable<Routine>> GetRoutines(UserId userId)
         {
-            var list = await _aggregateStorage.GetEventsAsync(_routine_entity, userId);
+            var list = await _aggregateStorage.GetEventsAsync(_routine_entity, userId.Item);
 
             return list.GroupBy(e => e.AggregateId)
                 .Select(g => new Routine(g));
         }
 
-        public Task SaveRoutine(Routine routine, Guid userId) =>
+        public Task SaveRoutine(Routine routine, UserId userId) =>
             Save(routine, _routine_entity, userId);
 
-        public async Task<Routine> GetRoutine(string name, Guid userId)
+        public async Task<Routine> GetRoutine(string name, UserId userId)
         {
             var list = await GetRoutines(userId);
             
             return list.SingleOrDefault(s => s.State.Name == name);
         }
 
-        public Task DeleteRoutine(Routine routine, Guid id) =>
-            _aggregateStorage.DeleteAggregate(entity: _routine_entity, aggregateId: routine.Id, userId: id);
+        public Task DeleteRoutine(Routine routine, UserId userId) =>
+            _aggregateStorage.DeleteAggregate(entity: _routine_entity, aggregateId: routine.Id, userId: userId.Item);
 
-        public async Task<IEnumerable<StockList>> GetStockLists(Guid userId)
+        public async Task<IEnumerable<StockList>> GetStockLists(UserId userId)
         {
-            var list = await _aggregateStorage.GetEventsAsync(_stock_list_entity, userId);
+            var list = await _aggregateStorage.GetEventsAsync(_stock_list_entity, userId.Item);
 
             return list.GroupBy(e => e.AggregateId)
                 .Select(g => new StockList(g));
         }
 
-        public async Task<StockList> GetStockList(string name, Guid userId)
+        public async Task<StockList> GetStockList(string name, UserId userId)
         {
             var list = await GetStockLists(userId);
             
             return list.SingleOrDefault(s => s.State.Name == name);
         }
 
-        public Task SaveStockList(StockList list, Guid userId) =>
+        public Task SaveStockList(StockList list, UserId userId) =>
             Save(list, _stock_list_entity, userId);
 
-        public Task DeleteStockList(StockList list, Guid userId) =>
-            _aggregateStorage.DeleteAggregate(entity: _stock_list_entity, aggregateId: list.Id, userId: userId);
+        public Task DeleteStockList(StockList list, UserId userId) =>
+            _aggregateStorage.DeleteAggregate(entity: _stock_list_entity, aggregateId: list.Id, userId: userId.Item);
 
-        public Task SavePendingPosition(PendingStockPosition position, Guid userId) =>
+        public Task SavePendingPosition(PendingStockPosition position, UserId userId) =>
             Save(position, _pending_stock_position_entity, userId);
 
-        public Task<IEnumerable<PendingStockPosition>> GetPendingStockPositions(Guid userId) =>
-            _aggregateStorage.GetEventsAsync(_pending_stock_position_entity, userId)
+        public Task<IEnumerable<PendingStockPosition>> GetPendingStockPositions(UserId userId) =>
+            _aggregateStorage.GetEventsAsync(_pending_stock_position_entity, userId.Item)
                 .ContinueWith(t => t.Result.GroupBy(e => e.AggregateId)
                     .Select(g => new PendingStockPosition(g)));
     }

--- a/src/web/BackgroundServices/EmailNotificationService.cs
+++ b/src/web/BackgroundServices/EmailNotificationService.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using core.fs.Alerts;
 using core.fs.Shared.Adapters.Storage;
+using core.fs.Shared.Domain.Accounts;
 using core.Shared.Adapters.Brokerage;
 using core.Shared.Adapters.Emails;
 using Microsoft.Extensions.Logging;
@@ -16,7 +17,7 @@ public class EmailNotificationService : GenericBackgroundServiceHost
     private readonly StockAlertContainer _container;
     private readonly IEmailService _emails;
     private readonly IMarketHours _marketHours;
-    Func<TimeSpan> _sleepFunction = null;
+    Func<TimeSpan> _sleepFunction;
 
     public EmailNotificationService(
         IAccountStorage accounts,
@@ -105,7 +106,7 @@ public class EmailNotificationService : GenericBackgroundServiceHost
 
                 _logger.LogInformation($"Sending email to {emailId.Id}");
 
-                var userOption = await _accounts.GetUser(new Guid(emailId.Id));
+                var userOption = await _accounts.GetUser(emailId.Id);
                 if (userOption.Value == null)
                 {
                     _logger.LogError("Unable to find user for " + emailId.Id);
@@ -115,7 +116,7 @@ public class EmailNotificationService : GenericBackgroundServiceHost
                 var user = userOption.Value;
 
                 // get all alerts for that user
-                var alertGroups = _container.GetAlerts(user.State.Id)
+                var alertGroups = _container.GetAlerts(emailId.Id)
                     .GroupBy(a => a.identifier)
                     .Select(ToAlertEmailGroup);
 

--- a/src/web/BackgroundServices/ThirtyDaySellService.cs
+++ b/src/web/BackgroundServices/ThirtyDaySellService.cs
@@ -57,7 +57,7 @@ namespace web.BackgroundServices
             // 30 day crosser
             _logger.LogInformation("Scanning {email}", p.Email);
 
-            var query = new SellsQuery(new Guid(p.Id));
+            var query = new SellsQuery(p.Id);
 
             var sellView = await _service.Handle(query);
 

--- a/src/web/BackgroundServices/WeeklyUpsideReversalService.cs
+++ b/src/web/BackgroundServices/WeeklyUpsideReversalService.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using core.Account;
 using core.fs.Shared.Adapters.Storage;
+using core.fs.Shared.Domain.Accounts;
 using core.Shared.Adapters.Brokerage;
 using core.Shared.Adapters.Emails;
 using core.Stocks.Services.Analysis;
@@ -111,10 +112,11 @@ public class WeeklyUpsideReversalService : GenericBackgroundServiceHost
                 var user = userOption.Value;
 
                 _logger.LogInformation("Processing user {email} upsides", emailId.Email);
-
-                var stocks = await _portfolioStorage.GetStocks(user.Id);
+                
+                var userId = UserId.NewUserId(user.Id);
+                var stocks = await _portfolioStorage.GetStocks(userId);
                 var tickersFromPositions = stocks.Where(s => s.State.OpenPosition != null).Select(s => s.State.OpenPosition.Ticker.Value);
-                var tickersFromLists = (await _portfolioStorage.GetStockLists(user.State.Id))
+                var tickersFromLists = (await _portfolioStorage.GetStockLists(userId))
                     .Where(l => l.State.ContainsTag(core.fs.Alerts.Constants.MonitorTagPattern))
                     .SelectMany(l => l.State.Tickers)
                     .Select(t => t.Ticker);

--- a/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-newposition.component.ts
+++ b/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-newposition.component.ts
@@ -11,7 +11,7 @@ import { GetErrors, GetStrategies, toggleVisuallyHidden } from 'src/app/services
 })
 export class StockTradingNewPositionComponent {
   strategies: { key: string; value: string; }[];
-  
+
   constructor(
       private stockService:StocksService,
       private datePipe: DatePipe
@@ -70,14 +70,14 @@ export class StockTradingNewPositionComponent {
   gaps: StockGaps
 
   onBuyTickerSelected(ticker: string) {
-    
+
     this.costToBuy = null
     this.numberOfShares = null
     this.sizeStopPrice = null
     this.positionStopPrice = null
     this.ticker = ticker
-    this.date = this.datePipe.transform(Date(), 'yyyy-MM-dd');
-    
+    // this.date = this.datePipe.transform(Date(), 'yyyy-MM-dd');
+
     this.stockService.getStockQuote(ticker)
       .subscribe(quote => {
         this.costToBuy = quote.mark
@@ -177,7 +177,7 @@ export class StockTradingNewPositionComponent {
 
     var singleShareLoss = this.costToBuy - this.sizeStopPrice
     this.numberOfShares = Math.floor(this.maxLoss / singleShareLoss)
-    
+
     this.updateBuyingValues(singleShareLoss)
   }
 
@@ -221,12 +221,14 @@ export class StockTradingNewPositionComponent {
     }
 
     this.stockService.purchase(cmd).subscribe(
-      _ => { 
+      _ => {
         this.stockPurchased.emit(cmd)
         this.recordInProgress = false
     },
-      _ => {
-        alert('purchase failed')
+      err => {
+        let errors = GetErrors(err)
+        let errorMessages = errors.join(", ")
+        alert('purchase failed: ' + errorMessages)
         this.recordInProgress = false
       }
     )
@@ -256,10 +258,10 @@ export class StockTradingNewPositionComponent {
         this.pendingPositionCreated.emit(cmd)
         this.reset()
       },
-      errors => { 
+      errors => {
         var errorMessageArray = GetErrors(errors)
         var errorMessages = errorMessageArray.join(", ")
-        alert('pending position failed: ' + errorMessages) 
+        alert('pending position failed: ' + errorMessages)
       }
     )
   }
@@ -274,10 +276,10 @@ export class StockTradingNewPositionComponent {
   lookupPendingPosition(ticker: string) {
     this.stockService.getPendingStockPositions().subscribe(
       positions => {
-        var position = positions.find(p => p.ticker === ticker)
+        let position = positions.find(p => p.ticker === ticker)
         if (position) {
           this.costToBuy = position.bid
-          this.numberOfShares = position.numberOfShares
+          this.numberOfShares = null
           this.positionStopPrice = position.stopPrice
           this.notes = position.notes
           this.strategy = position.strategy

--- a/src/web/Controllers/AdminController.cs
+++ b/src/web/Controllers/AdminController.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using core.fs.Accounts;
 using core.fs.Admin;
 using core.fs.Shared.Adapters.Storage;
+using core.fs.Shared.Domain.Accounts;
 using core.Shared.Adapters.Emails;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -31,9 +32,9 @@ namespace web.Controllers
         public ActionResult Test() => Ok();
 
         [HttpGet("loginas/{userId}")]
-        public async Task<ActionResult> LoginAs(Guid userId)
+        public async Task<ActionResult> LoginAs([FromRoute]Guid userId)
         {
-            var u = await _storage.GetUser(userId);
+            var u = await _storage.GetUser(UserId.NewUserId(userId));
             
             if (u.Value == null)
                 return NotFound();
@@ -45,7 +46,7 @@ namespace web.Controllers
 
         [HttpGet("delete/{userId}")]
         public Task<ActionResult> Delete([FromRoute]Guid userId, DeleteAccount.Handler service) =>
-            this.OkOrError(service.Handle(new DeleteAccount.Command(userId, null)));
+            this.OkOrError(service.Handle(new DeleteAccount.Command(UserId.NewUserId(userId), null)));
 
         [HttpPost("email")]
         public async Task<ActionResult> Email(EmailInput obj)
@@ -61,9 +62,9 @@ namespace web.Controllers
         }
 
         [HttpGet("welcome")]
-        public async Task<ActionResult> Welcome(Guid userId)
+        public async Task<ActionResult> Welcome([FromQuery]Guid userId)
         {
-            var user = await _storage.GetUser(userId);
+            var user = await _storage.GetUser(UserId.NewUserId(userId));
             
             if (user.Value == null)
                 return NotFound();

--- a/src/web/Controllers/EventsController.cs
+++ b/src/web/Controllers/EventsController.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using core.fs.Shared.Domain.Accounts;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using storage.shared;
@@ -23,9 +24,11 @@ namespace web.Controllers
         [HttpGet]
         public async Task<object> Index(string entity, Guid? userId, Guid? aggregateId)
         {
+            var u = userId == null ? null : UserId.NewUserId(userId.Value);
+            
             var list = await _storage.GetStoredEvents(
                 entity,
-                userId ?? User.Identifier());
+                u.Item);
 
             if (aggregateId != null)
             {

--- a/src/web/Controllers/StocksController.cs
+++ b/src/web/Controllers/StocksController.cs
@@ -60,7 +60,7 @@ namespace web.Controllers
         public Task<ActionResult> DeleteTransaction([FromRoute] string ticker, [FromRoute] Guid eventId) =>
             this.OkOrError(
                 _service.Handle(
-                    new DeleteTransaction(new Ticker(ticker), eventId, User.Identifier()
+                    new DeleteTransaction(new Ticker(ticker), User.Identifier(), eventId
                     )
                 )
             );

--- a/src/web/Utils/IdentityExtensions.cs
+++ b/src/web/Utils/IdentityExtensions.cs
@@ -1,14 +1,24 @@
 using System;
 using System.Security.Claims;
+using core.fs.Shared.Adapters.Storage;
+using core.fs.Shared.Domain.Accounts;
 
 namespace web.Utils
 {
     public static class IdentityExtensions
     {
         public const string ID_CLAIM_NAME = "userid";
-        
-        public static Guid Identifier(this System.Security.Claims.ClaimsPrincipal p)
-            => new Guid(GetClaimValue(p, ID_CLAIM_NAME) ?? Guid.Empty.ToString());
+
+        public static UserId Identifier(this ClaimsPrincipal p)
+        {
+            var guid = GetClaimValue(p, ID_CLAIM_NAME);
+            if (guid == null)
+            {
+                throw new Exception($"User is not authenticated. Missing claim: {ID_CLAIM_NAME}");
+            }
+
+            return UserId.NewUserId(new Guid(guid));
+        }
 
         public static string Email(this System.Security.Claims.ClaimsPrincipal p) 
             => GetClaimValue(p, ClaimTypes.Email);

--- a/tests/coretests/Alerts/StockAlertContainerTests.cs
+++ b/tests/coretests/Alerts/StockAlertContainerTests.cs
@@ -1,13 +1,15 @@
 using System;
 using System.Linq;
 using core.fs.Alerts;
+using core.fs.Shared.Domain.Accounts;
+using core.Shared;
 using Xunit;
 
 namespace coretests.Alerts
 {
     public class StockAlertContainerTests
     {
-        private readonly Guid _userId = Guid.NewGuid();
+        private readonly UserId _userId = UserId.NewUserId(Guid.NewGuid());
         private readonly StockAlertContainer _uat = new();
 
         public StockAlertContainerTests()
@@ -16,7 +18,7 @@ namespace coretests.Alerts
             {
                 _uat.Register(
                     TriggeredAlert.StopPriceAlert(
-                        ticker: "AMD", price: 100, stopPrice: 105, DateTimeOffset.Now, userId: _userId
+                        ticker: new Ticker("AMD"), price: 100, stopPrice: 105, DateTimeOffset.Now, userId: _userId
                     )
                 );
             }
@@ -30,6 +32,6 @@ namespace coretests.Alerts
         public void Alerts_ForUser_OnlyOne() => Assert.Single(_uat.GetAlerts(_userId));
 
         [Fact]
-        public void Alerts_ForDifferentUser_Empty() => Assert.Empty(_uat.GetAlerts(Guid.NewGuid()));
+        public void Alerts_ForDifferentUser_Empty() => Assert.Empty(_uat.GetAlerts(UserId.NewUserId(Guid.NewGuid())));
     }
 }

--- a/tests/coretests/Options/DashboardTests.cs
+++ b/tests/coretests/Options/DashboardTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using core.Account;
 using core.fs.Options;
 using core.fs.Shared.Adapters.Storage;
+using core.fs.Shared.Domain.Accounts;
 using core.Shared;
 using core.Shared.Adapters.Brokerage;
 using core.Shared.Adapters.CSV;
@@ -27,10 +28,10 @@ namespace coretests.Options
         {
             var (storage, _) = _fixture.CreateStorageWithSoldOption();
             
-            var query = new DashboardQuery(Guid.NewGuid());
+            var query = new DashboardQuery(UserId.NewUserId(Guid.NewGuid()));
 
             var accounts = new Mock<IAccountStorage>();
-            accounts.Setup(x => x.GetUser(It.IsAny<Guid>()))
+            accounts.Setup(x => x.GetUser(It.IsAny<UserId>()))
                 .Returns(Task.FromResult(
                         new FSharpOption<User>(
                             new User("e", "f", "l"))

--- a/tests/coretests/Options/DetailsTests.cs
+++ b/tests/coretests/Options/DetailsTests.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using core.Account;
 using core.fs.Options;
 using core.fs.Shared.Adapters.Storage;
+using core.fs.Shared.Domain.Accounts;
 using core.Shared;
 using core.Shared.Adapters.Brokerage;
 using core.Shared.Adapters.CSV;
@@ -27,10 +28,10 @@ namespace coretests.Options
         {
             var (storage, opt) = _fixture.CreateStorageWithSoldOption();
             
-            var query = new DetailsQuery(opt.State.Id, opt.State.UserId);
+            var query = new DetailsQuery(opt.State.Id, UserId.NewUserId(opt.State.UserId));
 
             var accountMock = new Mock<IAccountStorage>();
-            accountMock.Setup(x => x.GetUser(opt.State.UserId))
+            accountMock.Setup(x => x.GetUser(UserId.NewUserId(opt.State.UserId)))
                 .Returns(Task.FromResult(
                     new FSharpOption<User>(
                         new User("email", "f", "l")

--- a/tests/coretests/Options/OptionsTestsFixture.cs
+++ b/tests/coretests/Options/OptionsTestsFixture.cs
@@ -2,6 +2,7 @@ using System;
 using core.Account;
 using core.fs.Options;
 using core.fs.Shared.Adapters.Storage;
+using core.fs.Shared.Domain.Accounts;
 using core.Options;
 using core.Shared;
 using Moq;
@@ -29,16 +30,16 @@ namespace coretests.Options
                 cmd.Item1.StrikePrice.Value,
                 (OptionType)Enum.Parse(typeof(OptionType), cmd.Item1.OptionType),
                 cmd.Item1.ExpirationDate.Value,
-                cmd.Item2);
+                cmd.Item2.Item);
 
             opt.Sell(1, 20, DateTimeOffset.UtcNow, "some note");
 
             var mock = new Mock<IPortfolioStorage>();
 
-            mock.Setup(s => s.GetOwnedOptions(_user.Id))
+            mock.Setup(s => s.GetOwnedOptions(UserId.NewUserId(_user.Id)))
                 .ReturnsAsync(new[] { opt });
 
-            mock.Setup(s => s.GetOwnedOption(opt.Id, _user.Id))
+            mock.Setup(s => s.GetOwnedOption(opt.Id, UserId.NewUserId(_user.Id)))
                 .ReturnsAsync(opt);
 
             return (mock.Object, opt);
@@ -55,7 +56,7 @@ namespace coretests.Options
                 premium: 10,
                 filled: DateTimeOffset.UtcNow,
                 notes: null);
-            return BuyOrSellCommand.NewSell(cmd, _user.Id);
+            return BuyOrSellCommand.NewSell(cmd, UserId.NewUserId(_user.Id));
         }
 
         internal IAccountStorage CreateAccountStorageWithUserAsync()
@@ -65,7 +66,7 @@ namespace coretests.Options
             mock.Setup(s => s.GetUserByEmail(_user.State.Email))
                 .ReturnsAsync(_user);
 
-            mock.Setup(s => s.GetUser(_user.State.Id))
+            mock.Setup(s => s.GetUser(UserId.NewUserId(_user.State.Id)))
                 .ReturnsAsync(_user);
 
             return mock.Object;

--- a/tests/coretests/Options/SellOptionTests.cs
+++ b/tests/coretests/Options/SellOptionTests.cs
@@ -26,7 +26,7 @@ namespace coretests.Options
             var mock = new Mock<IPortfolioStorage>();
 
             mock.Setup(x => x.SaveOwnedOption(It.IsAny<OwnedOption>(), It.IsAny<UserId>()))
-                .Callback((OwnedOption option, Guid _) =>
+                .Callback((OwnedOption option, UserId _) =>
                 {
                     Assert.Equal(-1, option.State.NumberOfContracts);
                 });

--- a/tests/coretests/Options/SellOptionTests.cs
+++ b/tests/coretests/Options/SellOptionTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using core.fs.Options;
 using core.fs.Shared.Adapters.Storage;
+using core.fs.Shared.Domain.Accounts;
 using core.Options;
 using core.Shared.Adapters.Brokerage;
 using core.Shared.Adapters.CSV;
@@ -24,8 +25,8 @@ namespace coretests.Options
         {
             var mock = new Mock<IPortfolioStorage>();
 
-            mock.Setup(x => x.SaveOwnedOption(It.IsAny<OwnedOption>(), It.IsAny<Guid>()))
-                .Callback((OwnedOption option, Guid userId) =>
+            mock.Setup(x => x.SaveOwnedOption(It.IsAny<OwnedOption>(), It.IsAny<UserId>()))
+                .Callback((OwnedOption option, Guid _) =>
                 {
                     Assert.Equal(-1, option.State.NumberOfContracts);
                 });

--- a/tests/storagetests/AccountStorageTests.cs
+++ b/tests/storagetests/AccountStorageTests.cs
@@ -48,7 +48,7 @@ namespace storagetests
 
             Assert.True(FSharpOption<User>.get_IsNone(fromDbOption));
 
-            fromDbOption = await storage.GetUser(user.Id);
+            fromDbOption = await storage.GetUser(UserId.NewUserId(user.Id));
 
             Assert.True(FSharpOption<User>.get_IsNone(fromDbOption));
 
@@ -61,7 +61,7 @@ namespace storagetests
         {
             var storage = GetStorage();
 
-            var r = new ProcessIdToUserAssociation(Guid.NewGuid(), DateTimeOffset.UtcNow);
+            var r = new ProcessIdToUserAssociation(UserId.NewUserId(Guid.NewGuid()), DateTimeOffset.UtcNow);
 
             await storage.SaveUserAssociation(r);
 

--- a/tests/storagetests/PortfolioStorageTests.cs
+++ b/tests/storagetests/PortfolioStorageTests.cs
@@ -138,7 +138,7 @@ namespace storagetests
 
             await storage.SaveNote(note, _userId);
 
-            var fromDb = await storage.GetNote(IdentifierHelper.getUserId(_userId), UserId.NewUserId(note.State.Id));
+            var fromDb = await storage.GetNote(note.State.Id, _userId);
             
             Assert.Equal("new note", fromDb.State.Note);
 
@@ -318,8 +318,8 @@ namespace storagetests
             Assert.NotEmpty(existing);
             
             var loaded = await storage.GetNote(
-                IdentifierHelper.getUserId(_userId),
-                UserId.NewUserId(note.State.Id)
+                note.State.Id,
+                _userId
             );
             
             Assert.Equal(note.State.Note, loaded.State.Note);


### PR DESCRIPTION
Introducing UserId type that wraps Guid that then is used throughout the application to pass around user identifier. We don't have to worry about mixing up System.Guid types being passed to functions that accept userid and another guid parameter. While doing this change found two places where I was doing that without realizing and the tests had not caught it and I had not used that part of the application since the bug was introduced.

There is still Guid used in aggregates until I inverse the dependency of the aggregates to point to fsharp code.