### PR TITLE
Clean up how aggregate creates and exposes its state

### DIFF
--- a/src/core/Account/User.cs
+++ b/src/core/Account/User.cs
@@ -4,11 +4,8 @@ using core.Shared;
 
 namespace core.Account
 {
-    public class User : Aggregate
+    public class User : Aggregate<UserState>
     {
-        public UserState State { get; } = new UserState();
-        public override IAggregateState AggregateState => State;
-
         public User(IEnumerable<AggregateEvent> events) : base(events)
         {
         }

--- a/src/core/Cryptos/OwnedCrypto.cs
+++ b/src/core/Cryptos/OwnedCrypto.cs
@@ -5,11 +5,8 @@ using core.Shared;
 
 namespace core.Cryptos
 {
-    public class OwnedCrypto : Aggregate
+    public class OwnedCrypto : Aggregate<OwnedCryptoState>
     {
-        public OwnedCryptoState State { get; } = new OwnedCryptoState();
-        public override IAggregateState AggregateState => State;
-        
         public OwnedCrypto(IEnumerable<AggregateEvent> events) : base(events)
         {
         }
@@ -109,7 +106,7 @@ namespace core.Cryptos
 
         public void DeleteTransaction(Guid transactionId)
         {
-            if (!State.BuyOrSell.Any(t => t.Id == transactionId))
+            if (State.BuyOrSell.All(t => t.Id != transactionId))
             {
                 throw new InvalidOperationException("Unable to find transcation to delete using id " + transactionId);
             }

--- a/src/core/Notes/Note.cs
+++ b/src/core/Notes/Note.cs
@@ -4,11 +4,8 @@ using core.Shared;
 
 namespace core.Notes
 {
-    public class Note : Aggregate
+    public class Note : Aggregate<NoteState>
     {
-        public NoteState State { get; } = new NoteState();
-        public override IAggregateState AggregateState => State;
-
         public Note(IEnumerable<AggregateEvent> events) : base(events)
         {
         }

--- a/src/core/Options/OwnedOption.cs
+++ b/src/core/Options/OwnedOption.cs
@@ -4,12 +4,8 @@ using core.Shared;
 
 namespace core.Options
 {
-    public class OwnedOption : Aggregate
+    public class OwnedOption : Aggregate<OwnedOptionState>
      {
-         public OwnedOptionState State { get; } = new OwnedOptionState();
- 
-         public override IAggregateState AggregateState => State;
- 
          public OwnedOption(IEnumerable<AggregateEvent> events) : base(events)
          {
          }

--- a/src/core/Portfolio/PendingStockPosition.cs
+++ b/src/core/Portfolio/PendingStockPosition.cs
@@ -4,11 +4,8 @@ using core.Shared;
 
 namespace core.Portfolio
 {
-    public class PendingStockPosition : Aggregate
+    public class PendingStockPosition : Aggregate<PendingStockPositionState>
     {
-        public PendingStockPositionState State { get; } = new PendingStockPositionState();
-        public override IAggregateState AggregateState => State;
-
         public PendingStockPosition(IEnumerable<AggregateEvent> events) : base(events)
         {
         }

--- a/src/core/Portfolio/Routine.cs
+++ b/src/core/Portfolio/Routine.cs
@@ -5,12 +5,8 @@ using core.Shared;
 
 namespace core.Portfolio
 {
-    public class Routine : Aggregate
+    public class Routine : Aggregate<RoutineState>
     {
-        public RoutineState State { get; } = new RoutineState();
-
-        public override IAggregateState AggregateState => State;
-
         public Routine(IEnumerable<AggregateEvent> events) : base(events)
         {
         }

--- a/src/core/Portfolio/StockList.cs
+++ b/src/core/Portfolio/StockList.cs
@@ -4,12 +4,8 @@ using core.Shared;
 
 namespace core.Portfolio
 {
-    public class StockList : Aggregate
+    public class StockList : Aggregate<StockListState>
     {
-        public StockListState State { get; } = new StockListState();
-
-        public override IAggregateState AggregateState => State;
-
         public StockList(IEnumerable<AggregateEvent> events) : base(events)
         {
         }

--- a/src/core/Shared/Adapters/CSV/CSVExport.cs
+++ b/src/core/Shared/Adapters/CSV/CSVExport.cs
@@ -135,7 +135,7 @@ namespace core.Shared.Adapters.CSV
             return writer.Generate(rows);
         }
 
-        private static IEnumerable<object> StockEventToParts((Aggregate a, AggregateEvent ae) tuple)
+        private static IEnumerable<object> StockEventToParts((IAggregate a, AggregateEvent ae) tuple)
         {
             switch(tuple.ae)
             {

--- a/src/core/Stocks/OwnedStock.cs
+++ b/src/core/Stocks/OwnedStock.cs
@@ -5,11 +5,8 @@ using core.Shared;
 
 namespace core.Stocks
 {
-    public class OwnedStock : Aggregate
+    public class OwnedStock : Aggregate<OwnedStockState>
     {
-        public OwnedStockState State { get; } = new OwnedStockState();
-        public override IAggregateState AggregateState => State;
-        
         public OwnedStock(IEnumerable<AggregateEvent> events) : base(events)
         {
         }

--- a/src/infrastructure/storage.memory/MemoryAggregateStorage.cs
+++ b/src/infrastructure/storage.memory/MemoryAggregateStorage.cs
@@ -59,7 +59,7 @@ public class MemoryAggregateStorage : IAggregateStorage, IBlobStorage
         return Task.FromResult(_aggregates[key].AsEnumerable());
     }
 
-    public async Task SaveEventsAsync(Aggregate agg, string entity, UserId userId)
+    public async Task SaveEventsAsync(IAggregate agg, string entity, UserId userId)
     {
         var key = MakeKey(entity, userId);
 

--- a/src/infrastructure/storage.postgres/PostgresAggregateStorage.cs
+++ b/src/infrastructure/storage.postgres/PostgresAggregateStorage.cs
@@ -65,7 +65,7 @@ namespace storage.postgres
             return list.Select(e => e.Event);
         }
 
-        public async Task SaveEventsAsync(Aggregate agg, string entity, UserId userId)
+        public async Task SaveEventsAsync(IAggregate agg, string entity, UserId userId)
         {
             using var db = GetConnection();
             int version = agg.Version;

--- a/src/infrastructure/storage.shared/IAggregateStorage.cs
+++ b/src/infrastructure/storage.shared/IAggregateStorage.cs
@@ -9,7 +9,7 @@ namespace storage.shared
     public interface IAggregateStorage
     {
         Task<IEnumerable<AggregateEvent>> GetEventsAsync(string entity, UserId userId);
-        Task SaveEventsAsync(Aggregate agg, string entity, UserId userId);
+        Task SaveEventsAsync(IAggregate agg, string entity, UserId userId);
         Task DoHealthCheck();
         Task DeleteAggregates(string entity, UserId userId);
         Task DeleteAggregate(string entity, Guid aggregateId, UserId userId);

--- a/src/infrastructure/storage.shared/PortfolioStorage.cs
+++ b/src/infrastructure/storage.shared/PortfolioStorage.cs
@@ -68,7 +68,7 @@ namespace storage.shared
             return Save(option, _option_entity, userId);
         }
 
-        private Task Save(Aggregate agg, string entityName, UserId userId)
+        private Task Save(IAggregate agg, string entityName, UserId userId)
         {
             return _aggregateStorage.SaveEventsAsync(agg, entityName, userId);
         }

--- a/src/web/BackgroundServices/StockAlertService.cs
+++ b/src/web/BackgroundServices/StockAlertService.cs
@@ -165,6 +165,7 @@ namespace web.BackgroundServices
             
             var users = await _accounts.GetUserEmailIdPairs();
 
+            var alertList = new List<AlertCheck>();
             foreach(var emailIdPair in users)    
             {
                 var userOption = await _accounts.GetUser(emailIdPair.Id);
@@ -172,11 +173,12 @@ namespace web.BackgroundServices
                 var list = (await _portfolio.GetStockLists(emailIdPair.Id))
                     .Where(l => l.State.ContainsTag(Constants.MonitorTagPattern))
                     .SelectMany(l => l.State.Tickers.Select(t => (l, t)))
-                    .Select(listTickerPair => new AlertCheck(ticker: listTickerPair.t.Ticker, listName: listTickerPair.l.State.Name, user: user.State))
-                    .ToList();
-
-                _listChecks.Add(Constants.MonitorTagPattern, list);
+                    .Select(listTickerPair => new AlertCheck(ticker: listTickerPair.t.Ticker,
+                        listName: listTickerPair.l.State.Name, user: user.State));
+                alertList.AddRange(list);
             }
+            
+            _listChecks.Add(Constants.MonitorTagPattern, alertList);
 
             _nextListMonitoringRun = MonitoringServices.nextMonitoringRun(
                 DateTimeOffset.UtcNow,

--- a/tests/coretests/Portfolio/StockListTests.cs
+++ b/tests/coretests/Portfolio/StockListTests.cs
@@ -10,7 +10,7 @@ namespace coretests.Portfolio
         private static Guid _userId = Guid.NewGuid();
 
         private static StockList Create(string name, string description) =>
-            new StockList(description: description, name: name, userId: _userId);
+            new(description: description, name: name, userId: _userId);
         
         [Fact]
         public void CreateWorks()
@@ -104,14 +104,14 @@ namespace coretests.Portfolio
 
             list.AddStock("aapl", "note");
 
-            var events = list.Events.Count;
+            var events = list.Events.Count();
 
             list.AddStock("aapl", "note");
             list.AddStock("aapl", "note");
 
 
             Assert.Single(list.State.Tickers);
-            Assert.Equal(events, list.Events.Count);
+            Assert.Equal(events, list.Events.Count());
         }
 
         [Fact]


### PR DESCRIPTION
I tried converting aggregates to fsharp and in the process discovered that my approach to how aggregates created the state type was a bit problematic. Basically base Aggregate class would invoke access an AggregateState property that would depend on the Aggregate subclass to initialize. I didn't realize this dependency existed until f# strict initialization flow exposed as a problem. Basically you can create an Aggregate class without AggregateState initialized and you wouldn't know any better until run time error.

Changing this so that AggregateState is ALWAYS instantiated, by the Aggregate base.