### PR TITLE
Remove hardcoded admin email, introduce user settings concept

### DIFF
--- a/dev.bat
+++ b/dev.bat
@@ -4,6 +4,7 @@ REM set storage=[postgres|memory]
 REM set DB_CNN=Server=...;Database=...;User id=...;password=... # database connection string
 REM set GoogleClientId=...  # for google oauth, get client id from google console
 REM set GoogleSecret=... # for google oauth, get secret from google console
+REM set ADMINEmail=... # email address for admin user, when a user with this address logs in, they have more privileges
 
 REM set COINMARKETCAPToken=.... # coinmarketcap token that you will need for crypto prices
 

--- a/src/core.fs/Accounts/Handlers.fs
+++ b/src/core.fs/Accounts/Handlers.fs
@@ -25,6 +25,7 @@ namespace core.fs.Accounts
             SubscriptionLevel : string
             ConnectedToBrokerage: bool
             BrokerageAccessTokenExpired: bool
+            MaxLoss: decimal option
         }
 
         static member fromUserState (isAdmin:bool) (state:UserState) =
@@ -40,6 +41,7 @@ namespace core.fs.Accounts
                 SubscriptionLevel = state.SubscriptionLevel
                 ConnectedToBrokerage = state.ConnectedToBrokerage
                 BrokerageAccessTokenExpired = state.BrokerageAccessTokenExpired
+                MaxLoss = if state.MaxLoss.HasValue then Some state.MaxLoss.Value else None
             }
             
         static member notFound() =
@@ -55,6 +57,7 @@ namespace core.fs.Accounts
                 SubscriptionLevel = null
                 ConnectedToBrokerage = false
                 BrokerageAccessTokenExpired = true
+                MaxLoss = None 
             }    
     
     module Authenticate =

--- a/src/core.fs/Shared/Domain/Accounts/Types.fs
+++ b/src/core.fs/Shared/Domain/Accounts/Types.fs
@@ -1,7 +1,6 @@
 ﻿namespace core.fs.Shared.Domain.Accounts
 
 open System
-open System.Collections
 open core.Account
 open core.Shared
 
@@ -93,4 +92,8 @@ type User(events:System.Collections.Generic.IEnumerable<AggregateEvent>) =
         
     member this.RequestPasswordReset ``when`` =
         let event = UserPasswordResetRequested(Guid.NewGuid(), this.Id, ``when``)
+        this.Apply(event)
+        
+    member this.SetSetting name value =
+        let event = UserSettingSet(Guid.NewGuid(), this.Id, DateTimeOffset.UtcNow, name, value)
         this.Apply(event)

--- a/src/core/Account/Events.cs
+++ b/src/core/Account/Events.cs
@@ -150,4 +150,16 @@ namespace core.Account
         {
         }
     }
+
+    public class UserSettingSet : AggregateEvent
+    {
+        public UserSettingSet(Guid id, Guid aggregateId, DateTimeOffset when, string key, string value) : base(id, aggregateId, when)
+        {
+            Key = key;
+            Value = value;
+        }
+
+        public string Value { get; }
+        public string Key { get; }
+    }
 }

--- a/src/core/Account/UserState.cs
+++ b/src/core/Account/UserState.cs
@@ -23,7 +23,7 @@ namespace core.Account
         public DateTimeOffset BrokerageAccessTokenExpires { get; private set; }
         public bool ConnectedToBrokerage { get; private set; }
         public bool BrokerageAccessTokenExpired => BrokerageAccessTokenExpires < DateTimeOffset.UtcNow;
-        public decimal MaxLoss { get; private set; }
+        public decimal? MaxLoss { get; private set; }
 
         internal void ApplyInternal(UserCreated c)
         {

--- a/src/core/Account/UserState.cs
+++ b/src/core/Account/UserState.cs
@@ -15,7 +15,7 @@ namespace core.Account
         public DateTimeOffset? Deleted { get; private set; }
         public string DeleteFeedback { get; private set; }
         public DateTimeOffset? Verified { get; private set; }
-        public string SubscriptionLevel { get; private set; }
+        public string SubscriptionLevel { get; private set; } = "Free";
         public bool IsPasswordAvailable => GetSalt() != null;
         public string Name => $"{Firstname} {Lastname}";
         public string BrokerageAccessToken { get; private set; }
@@ -23,11 +23,7 @@ namespace core.Account
         public DateTimeOffset BrokerageAccessTokenExpires { get; private set; }
         public bool ConnectedToBrokerage { get; private set; }
         public bool BrokerageAccessTokenExpired => BrokerageAccessTokenExpires < DateTimeOffset.UtcNow;
-
-        public UserState()
-        {
-            SubscriptionLevel = "Free";
-        }
+        public decimal MaxLoss { get; private set; }
 
         internal void ApplyInternal(UserCreated c)
         {
@@ -66,7 +62,7 @@ namespace core.Account
             // SubscriptionLevel = p.PlanId == Plans.Starter ? "Starter" : "Full";
         }
 
-        internal static void ApplyInternal(UserPasswordResetRequested _)
+        internal void ApplyInternal(UserPasswordResetRequested _)
         {
             // no state to modify, this event gets captured via INotification mechanism
         }
@@ -85,6 +81,19 @@ namespace core.Account
             BrokerageAccessToken = null;
             BrokerageRefreshToken = null;
             BrokerageAccessTokenExpires = DateTimeOffset.MinValue;
+        }
+
+        internal void ApplyInternal(UserSettingSet e)
+        {
+            switch (e.Key)
+            {
+                case "maxLoss":
+                    var maxLoss = Decimal.Parse(e.Value);
+                    MaxLoss = maxLoss;
+                    break;
+                default:
+                    throw new InvalidOperationException($"Unknown setting: {e.Key}");
+            }
         }
 
         public bool PasswordHashMatches(string hash)

--- a/src/core/Shared/Adapters/Emails/EmailSettings.cs
+++ b/src/core/Shared/Adapters/Emails/EmailSettings.cs
@@ -1,8 +1,23 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace core.Shared.Adapters.Emails
 {
+    public class EmailInput
+    {
+        [Required]
+        public string From { get; set; }
+        [Required]
+        public string FromName { get; set; }
+        [Required]
+        public string Subject { get; set; }
+        [Required]
+        public string Body { get; set; }
+        [Required]
+        public string To { get; set; }
+    }
+    
     public static class EmailSettings
     {
-        public static readonly Recipient Admin = new(email: "laimis@gmail.com", name: null);
         public const string PasswordResetUrl = "https://www.nightingaletrading.com/profile/passwordreset";
         public const string ConfirmAccountUrl = "https://www.nightingaletrading.com/api/account/confirm";
     }

--- a/src/core/Shared/Adapters/Emails/IEmailService.cs
+++ b/src/core/Shared/Adapters/Emails/IEmailService.cs
@@ -6,5 +6,8 @@ namespace core.Shared.Adapters.Emails
     {
         Task Send(Recipient recipient, Sender sender, EmailTemplate template, object properties);
         Task Send(Recipient recipient, Sender sender, string subject, string body);
+        Task Send(EmailInput input);
     }
+    
+    
 }

--- a/src/core/Shared/Adapters/IRoleService.cs
+++ b/src/core/Shared/Adapters/IRoleService.cs
@@ -1,0 +1,9 @@
+using core.Account;
+
+namespace core.Shared.Adapters;
+
+public interface IRoleService
+{
+    bool IsAdmin(UserState user);
+    string GetAdminEmail();
+}

--- a/src/infrastructure/sendgridclient/SendGridClientImpl.cs
+++ b/src/infrastructure/sendgridclient/SendGridClientImpl.cs
@@ -56,6 +56,13 @@ namespace sendgridclient
             _logger.LogInformation("Sendgrid status {statusCode} with body: {responseBody}", response.StatusCode, responseBody);
         }
 
+        public Task Send(EmailInput obj) => Send(
+            recipient: new Recipient(email: obj.To, name: null),
+            sender: new Sender(obj.From, obj.FromName),
+            subject: obj.Subject,
+            body: obj.Body
+        );
+
         public Task Send(
             Recipient recipient,
             Sender sender,

--- a/src/web/AuthHelper.cs
+++ b/src/web/AuthHelper.cs
@@ -8,8 +8,13 @@ namespace web
 {
     public class AuthHelper
     {
-        internal static void Configure(IConfiguration configuration, IServiceCollection services)
+        internal static void Configure(IConfiguration configuration, IServiceCollection services, string adminEmail)
         {
+            if (string.IsNullOrWhiteSpace(adminEmail))
+            {
+                throw new System.Exception("ADMINEmail is not set");
+            }
+            
             var authBuilder = services.AddAuthentication(options =>
             {
                 options.DefaultAuthenticateScheme = CookieAuthenticationDefaults.AuthenticationScheme;
@@ -34,7 +39,7 @@ namespace web
             }
 
             services.AddAuthorization(opt => 
-                opt.AddPolicy("admin", p => p.RequireClaim(ClaimTypes.Email, "laimis@gmail.com"))
+                opt.AddPolicy("admin", p => p.RequireClaim(ClaimTypes.Email, adminEmail))
             );
         }
     }

--- a/src/web/ClientApp/src/app/auth/auth.guard.ts
+++ b/src/web/ClientApp/src/app/auth/auth.guard.ts
@@ -23,7 +23,7 @@ export class AuthGuard  {
       this.router.navigate(['/profile/verify'])
       return false;
     }
-    this.globalService.markLoggedIn()
+    this.globalService.markLoggedIn(result)
     return true;
   }
 }
@@ -43,7 +43,7 @@ export class AuthGuardUnverifiedAllowed  {
      this.router.navigate(['/landing'])
      return false;
    }
-   this.globalService.markLoggedIn()
+   this.globalService.markLoggedIn(result)
    return true;
  }
 }
@@ -63,7 +63,7 @@ export class AuthGuardAdminOnly  {
      this.router.navigate(['/unauthorized'])
      return false;
    }
-   this.globalService.markLoggedIn()
+   this.globalService.markLoggedIn(result)
    return true;
  }
 }

--- a/src/web/ClientApp/src/app/nav-menu/nav-menu.component.ts
+++ b/src/web/ClientApp/src/app/nav-menu/nav-menu.component.ts
@@ -23,7 +23,7 @@ export class NavMenuComponent {
     public globalService: GlobalService,
     private router: Router
   ) {
-    this.globalService.customVariable.subscribe((value) => {
+    this.globalService.accountStatusFeed.subscribe((value) => {
       this.isLoggedIn = value.loggedIn;
     });
 

--- a/src/web/ClientApp/src/app/nav-menu/nav-menu.component.ts
+++ b/src/web/ClientApp/src/app/nav-menu/nav-menu.component.ts
@@ -24,7 +24,7 @@ export class NavMenuComponent {
     private router: Router
   ) {
     this.globalService.customVariable.subscribe((value) => {
-      this.isLoggedIn = value.isLoggedIn;
+      this.isLoggedIn = value.loggedIn;
     });
 
     this.router.events.subscribe((val) => {

--- a/src/web/ClientApp/src/app/profile/profile-login.component.ts
+++ b/src/web/ClientApp/src/app/profile/profile-login.component.ts
@@ -44,9 +44,9 @@ export class ProfileLoginComponent implements OnInit {
       password: this.password
     }
 
-    this.stockService.loginAccount(obj).subscribe(_ => {
+    this.stockService.loginAccount(obj).subscribe(status => {
       console.log("logged in setting global variable")
-      this.globalService.markLoggedIn()
+      this.globalService.markLoggedIn(status)
       this.router.navigateByUrl(this.returnUrl)
     }, err => {
       this.inProgress = false
@@ -59,11 +59,11 @@ export class ProfileLoginComponent implements OnInit {
     this.errors = null
     this.passwordRequestSuccess = false
 
-    var obj = {
+    let obj = {
       email: this.email
     }
 
-    this.stockService.requestPasswordReset(obj).subscribe(r => {
+    this.stockService.requestPasswordReset(obj).subscribe(_ => {
       this.email = null
       this.passwordRequestSuccess = true
     }, err => {

--- a/src/web/ClientApp/src/app/profile/profile.component.html
+++ b/src/web/ClientApp/src/app/profile/profile.component.html
@@ -22,6 +22,21 @@
     </div>
   </div>
 
+  <!-- settings section -->
+  <div class="card mb-3" *ngIf="profile">
+    <div class="card-header">
+      Settings
+    </div>
+    <div class="card-body">
+      <div class="row">
+        <div class="col">
+          <label for="maxLoss" class="form-label">Max Loss</label>
+          <input type="number" #maxLoss class="form-control" name="maxLoss" id="maxLoss" [(ngModel)]="profile.maxLoss" (change)="updateMaxLoss(maxLoss.value)">
+        </div>
+      </div>
+    </div>
+  </div>
+
   <!-- Integrations section -->
   <div class="card mb-3" *ngIf="profile">
     <div class="card-header">

--- a/src/web/ClientApp/src/app/profile/profile.component.ts
+++ b/src/web/ClientApp/src/app/profile/profile.component.ts
@@ -1,7 +1,8 @@
 import { Component, OnInit } from '@angular/core';
-import { StocksService, AccountStatus } from '../services/stocks.service';
+import {StocksService, AccountStatus, KeyValuePair} from '../services/stocks.service';
 import { Router } from '@angular/router';
 import { GetErrors } from '../services/utils';
+import {GlobalService} from "../services/global.service";
 
 @Component({
   selector: 'app-profile',
@@ -20,11 +21,15 @@ export class ProfileComponent implements OnInit {
 
   deleteFeedback: string = ''
 
-  constructor(private service:StocksService, private router:Router) { }
+  constructor(
+    private global:GlobalService,
+    private service:StocksService,
+    private router:Router) { }
 
   ngOnInit() {
-    this.service.getProfile().subscribe(p => {
-      this.profile = p
+    this.global.customVariable.subscribe(s => {
+      console.log("profile component")
+      this.profile = s
     })
   }
 
@@ -39,6 +44,14 @@ export class ProfileComponent implements OnInit {
 
   undoDelete() {
     this.showDelete = false
+  }
+
+  updateMaxLoss(value:string) {
+    let keyValue : KeyValuePair = {key:"maxLoss", value:value}
+    this.service.updateAccountSettings(keyValue).subscribe(
+      s => this.profile.maxLoss = s.maxLoss,
+      error => console.log(error)
+    )
   }
 
   deleteFinal() {

--- a/src/web/ClientApp/src/app/profile/profile.component.ts
+++ b/src/web/ClientApp/src/app/profile/profile.component.ts
@@ -27,7 +27,7 @@ export class ProfileComponent implements OnInit {
     private router:Router) { }
 
   ngOnInit() {
-    this.global.customVariable.subscribe(s => {
+    this.global.accountStatusFeed.subscribe(s => {
       console.log("profile component")
       this.profile = s
     })

--- a/src/web/ClientApp/src/app/services/global.service.ts
+++ b/src/web/ClientApp/src/app/services/global.service.ts
@@ -6,10 +6,10 @@ import {AccountStatus} from "./stocks.service";
   providedIn: 'root'
 })
 export class GlobalService {
-  public customVariable = new BehaviorSubject<AccountStatus>(new AccountStatus());
+  public accountStatusFeed = new BehaviorSubject<AccountStatus>(new AccountStatus());
 
   markLoggedIn(accountStatus:AccountStatus) {
-    this.customVariable.next(accountStatus)
+    this.accountStatusFeed.next(accountStatus)
   }
 }
 

--- a/src/web/ClientApp/src/app/services/global.service.ts
+++ b/src/web/ClientApp/src/app/services/global.service.ts
@@ -1,17 +1,15 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
+import {AccountStatus} from "./stocks.service";
 
 @Injectable({
   providedIn: 'root'
 })
 export class GlobalService {
-  public customVariable = new BehaviorSubject<any>({
-    isLoggedIn: false
-  });
+  public customVariable = new BehaviorSubject<AccountStatus>(new AccountStatus());
 
-  markLoggedIn() {
-    this.customVariable.value.isLoggedIn = true
-    this.customVariable.next(this.customVariable.value)
+  markLoggedIn(accountStatus:AccountStatus) {
+    this.customVariable.next(accountStatus)
   }
 }
 

--- a/src/web/ClientApp/src/app/services/stocks.service.ts
+++ b/src/web/ClientApp/src/app/services/stocks.service.ts
@@ -379,8 +379,8 @@ export class StocksService {
     return this.http.post<object>('/api/account/validate', obj)
   }
 
-  loginAccount(obj:object) : Observable<object> {
-    return this.http.post<object>('/api/account/login', obj)
+  loginAccount(obj:object) : Observable<AccountStatus> {
+    return this.http.post<AccountStatus>('/api/account/login', obj)
   }
 
   requestPasswordReset(obj:object) : Observable<object> {
@@ -401,6 +401,10 @@ export class StocksService {
 
   sendMessage(obj: { email: string; message: string; }) {
     return this.http.post<object>('/api/account/contact', obj)
+  }
+
+  updateAccountSettings(obj:KeyValuePair) : Observable<AccountStatus> {
+    return this.http.post<AccountStatus>('/api/account/settings', obj)
   }
 
   // ------------------- payments ------------------------
@@ -1227,8 +1231,8 @@ export interface OptionChain {
   options: OptionDefinition[]
 }
 
-export interface AccountStatus {
-  username: String
+export class AccountStatus {
+  username: string
   email: string
   firstname: string
   lastname: string
@@ -1238,6 +1242,7 @@ export interface AccountStatus {
   isAdmin: boolean
   subscriptionLevel: string
   connectedToBrokerage: boolean
+  maxLoss: number
 }
 
 export interface TrackingPreview {

--- a/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-newposition.component.ts
+++ b/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-newposition.component.ts
@@ -11,6 +11,7 @@ import {
   TickerOutcomes
 } from 'src/app/services/stocks.service';
 import { GetErrors, GetStrategies, toggleVisuallyHidden } from 'src/app/services/utils';
+import {GlobalService} from "../../services/global.service";
 
 @Component({
   selector: 'app-stock-trading-newposition',
@@ -22,14 +23,19 @@ export class StockTradingNewPositionComponent {
   strategies: { key: string; value: string; }[];
   chartInfo: PositionChartInformation;
   prices: Prices;
+  private maxLoss = 60;
 
-  constructor(private stockService:StocksService)
+  constructor(
+    private stockService:StocksService,
+    globalService:GlobalService)
   {
     this.strategies = GetStrategies()
+    globalService.accountStatusFeed.subscribe(value => {
+      if (value.maxLoss) {
+        this.maxLoss = value.maxLoss
+      }
+    })
   }
-
-  @Input()
-  maxLoss: number = 60
 
   @Input()
   showChart: boolean = true

--- a/src/web/Controllers/AccountController.cs
+++ b/src/web/Controllers/AccountController.cs
@@ -22,7 +22,7 @@ namespace web.Controllers
         {
             if (User.Identity is { IsAuthenticated: false })
             {
-                var view = Status.AccountStatusView.notFound();
+                var view = AccountStatusView.notFound();
                 return Task.FromResult<ActionResult>(Ok(view));
             }
 
@@ -65,14 +65,14 @@ namespace web.Controllers
             return this.OkOrError(r);
         }
 
-        internal static async Task EstablishSignedInIdentity(HttpContext context, User user)
+        internal static async Task EstablishSignedInIdentity(HttpContext context, AccountStatusView user)
         {
             var claims = new List<Claim>
             {
-                new Claim(ClaimTypes.GivenName,             user.State.Firstname),
-                new Claim(ClaimTypes.Surname,               user.State.Lastname),
-                new Claim(ClaimTypes.Email,                 user.State.Email),
-                new Claim(IdentityExtensions.ID_CLAIM_NAME, user.State.Id.ToString())
+                new(ClaimTypes.GivenName,             user.Firstname),
+                new(ClaimTypes.Surname,               user.Lastname),
+                new(ClaimTypes.Email,                 user.Email),
+                new(IdentityExtensions.ID_CLAIM_NAME, user.Id.ToString())
             };
 
             var claimsIdentity = new ClaimsIdentity(
@@ -226,5 +226,10 @@ namespace web.Controllers
 
             return Redirect("~/");
         }
+        
+        [HttpPost("settings")]
+        [Authorize]
+        public Task<ActionResult> Settings([FromBody]Settings.Command cmd, [FromServices]Settings.Handler service)
+            => this.OkOrError(service.Handle(cmd.WithUserId(User.Identifier())));
     }
 }

--- a/src/web/DIHelper.cs
+++ b/src/web/DIHelper.cs
@@ -29,6 +29,9 @@ namespace web
             IServiceCollection services,
             ILogger logger)
         {
+            services.AddSingleton<IRoleService>(s => new RoleService(
+                configuration.GetValue<string>("ADMINEmail")
+            ));
             services.AddSingleton<core.fs.Shared.Adapters.Logging.ILogger, GenericLogger>();
             services.AddSingleton<coinmarketcap.CoinMarketCapClient>(s =>
                 new coinmarketcap.CoinMarketCapClient(

--- a/src/web/Startup.cs
+++ b/src/web/Startup.cs
@@ -31,7 +31,7 @@ namespace web
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            AuthHelper.Configure(Configuration, services);
+            AuthHelper.Configure(Configuration, services, Configuration.GetValue<string>("ADMINEmail"));
 
             services
                 .AddControllers(

--- a/src/web/Utils/RoleService.cs
+++ b/src/web/Utils/RoleService.cs
@@ -1,0 +1,18 @@
+using core.Account;
+using core.Shared.Adapters;
+
+namespace web.Utils;
+
+public class RoleService : IRoleService
+{
+    private readonly string _adminEmail;
+
+    public RoleService(string adminEmail)
+    {
+        _adminEmail = adminEmail;
+    }
+    
+    public bool IsAdmin(UserState user) => user.Email == _adminEmail;
+
+    public string GetAdminEmail() => _adminEmail;
+}

--- a/tests/coretests/Account/UserTests.cs
+++ b/tests/coretests/Account/UserTests.cs
@@ -1,18 +1,22 @@
 using System;
 using System.Linq;
-using System.Runtime.Serialization;
 using core.fs.Shared.Adapters.Subscriptions;
 using core.fs.Shared.Domain.Accounts;
+using coretests.testdata;
 using Xunit;
 
 namespace coretests.Account
 {
     public class UserTests
     {
+        public UserTests()
+        {
+        }
+
         [Fact]
         public void CreatingSetsId()
         {
-            var u = User.Create("laimis@gmail.com", "firstname", "last");
+            var u = User.Create(TestDataGenerator.RandomEmail(), "firstname", "last");
 
             Assert.NotEqual(Guid.Empty, u.State.Id);
         }
@@ -29,7 +33,7 @@ namespace coretests.Account
         [Fact]
         public void SettingPasswordMatchEvalCorrect()
         {
-            var u = User.Create("laimis@gmail.com", "firstname", "last");
+            var u = User.Create(TestDataGenerator.RandomEmail(), "firstname", "last");
 
             u.SetPassword("hash", "salt");
 
@@ -39,7 +43,7 @@ namespace coretests.Account
         [Fact]
         public void Deleting_MarksAsDeleted()
         {
-            var u = User.Create("laimis@gmail.com", "firstname", "last");
+            var u = User.Create(TestDataGenerator.RandomEmail(), "firstname", "last");
 
             u.Delete("delete feedback");
 
@@ -50,7 +54,7 @@ namespace coretests.Account
         [Fact]
         public void RequestPasswordReset()
         {
-            var u = User.Create("laimis@gmail.com", "firstname", "last");
+            var u = User.Create(TestDataGenerator.RandomEmail(), "firstname", "last");
 
             u.RequestPasswordReset(DateTimeOffset.UtcNow);
 
@@ -60,11 +64,37 @@ namespace coretests.Account
         [Fact]
         public void Subscribe()
         {
-            var u = User.Create("laimis@gmail.com", "firstname", "last");
+            var u = User.Create(TestDataGenerator.RandomEmail(), "firstname", "last");
 
             u.SubscribeToPlan(Plans.Full, "customer", "subscription");
             // TODO: bring it back once fsharp conversion is done
             // Assert.Equal(nameof(Plans.Full), u.State.SubscriptionLevel);
+        }
+
+        [Fact]
+        public void SetSetting()
+        {
+            var u = User.Create(TestDataGenerator.RandomEmail(), "firstname", "last");
+
+            u.SetSetting("maxLoss", "60");
+            
+            Assert.Equal(60m, u.State.MaxLoss);
+        }
+        
+        [Fact]
+        public void SetSetting_InvalidKey()
+        {
+            var u = User.Create(TestDataGenerator.RandomEmail(), "firstname", "last");
+
+            Assert.Throws<InvalidOperationException>(() => u.SetSetting("maxloss", "60.1"));
+        }
+        
+        [Fact]
+        public void SetSetting_InvalidValue()
+        {
+            var u = User.Create(TestDataGenerator.RandomEmail(), "firstname", "last");
+
+            Assert.Throws<FormatException>(() => u.SetSetting("maxLoss", "large"));
         }
     }
 }

--- a/tests/coretests/testdata/TestDataGenerator.cs
+++ b/tests/coretests/testdata/TestDataGenerator.cs
@@ -12,7 +12,7 @@ namespace coretests.testdata
             var content = File.ReadAllText($"testdata/pricefeed_{ticker}.txt");
 
             return content.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries)
-                .Select(x => PriceBar.Parse(x))
+                .Select(PriceBar.Parse)
                 .ToArray();
         }
 
@@ -34,5 +34,7 @@ namespace coretests.testdata
                     )
                 .ToArray();
         }
+        
+        public static string RandomEmail() => $"{Guid.NewGuid().ToString()}@gmail.com";
     }
 }

--- a/tests/storagetests/AccountStorageTests.cs
+++ b/tests/storagetests/AccountStorageTests.cs
@@ -39,9 +39,19 @@ namespace storagetests
             Assert.Equal("firstname", fromDb.State.Firstname);
             Assert.Equal("lastname", fromDb.State.Lastname);
 
+            // change settings, save, reload
+            fromDb.SetSetting("maxLoss", "60");
+            
+            await storage.Save(fromDb);
+            
+            fromDbOption = await storage.GetUserByEmail(email);
+            
+            Assert.NotNull(fromDbOption.Value);
+            Assert.Equal(60, fromDbOption.Value.State.MaxLoss);
+
             var users = await storage.GetUserEmailIdPairs();
             Assert.NotEmpty(users.Where(u => u.Email == email));
-
+            
             await storage.Delete(user);
 
             fromDbOption = await storage.GetUserByEmail(email);


### PR DESCRIPTION
Long overdue changes. Adding ability to configure admin email address. Also, adding a concept of user settings where we can set user level settings without having them in the config files. The first setting that will be used for this is to set "maxLoss" parameter that will be used in calculating how many shares can be obtained for the position.