### PR TITLE
Migrating serviceresponse to Ok or Error union type

### DIFF
--- a/src/core.fs/Alerts/Handlers.fs
+++ b/src/core.fs/Alerts/Handlers.fs
@@ -67,17 +67,17 @@ namespace core.fs.Alerts
             
             member this.Handle (send:SendSMS) = task {
                 do! smsService.SendSMS(send.Body)
-                return ServiceResponse()
+                return Ok
             }
             
             member this.Handle (_:TurnSMSOn) = task {
                 smsService.TurnOn()
-                return ServiceResponse()
+                return Ok
             }
             
             member this.Handle (_:TurnSMSOff) = task {
                 smsService.TurnOff()
-                return ServiceResponse()
+                return Ok
             }
             
             member this.Handle (_:Status) = task {

--- a/src/core.fs/Brokerage/Handlers.fs
+++ b/src/core.fs/Brokerage/Handlers.fs
@@ -60,7 +60,7 @@ module core.fs.Brokerage
                 return "User not found" |> ResponseUtils.failed 
             | Some user ->
                 let! _ = user.State |> func data
-                return ServiceResponse()
+                return Ok
         }
         
         member _.Handle (command:CancelOrder) = task {
@@ -70,7 +70,7 @@ module core.fs.Brokerage
             | None -> return ResponseUtils.failed "User not found"
             | Some user ->
                 let! _ = brokerage.CancelOrder(user.State, command.OrderId)
-                return ServiceResponse()
+                return Ok
         }
         
         member _.Handle (query:QueryAccount) = task {

--- a/src/core.fs/Cryptos/Handlers.fs
+++ b/src/core.fs/Cryptos/Handlers.fs
@@ -129,7 +129,7 @@ namespace core.fs.Cryptos
             
         let ``yield`` (data:CryptoTransaction) (crypto:OwnedCrypto) =
             crypto.Yield(data.Quantity,data.DollarAmount,data.Date,data.Notes)
-        
+            
         interface IApplicationService
         
         member _.Handle(cmd:CryptoTransactionWithUserId) = task {
@@ -159,7 +159,7 @@ namespace core.fs.Cryptos
                     
                     do! portfolio.SaveCrypto cryptoToUse userId
                 
-                    return ServiceResponse()
+                    return Ok
         }
         
         member _.Handle(query:DashboardQuery) = task {
@@ -190,7 +190,7 @@ namespace core.fs.Cryptos
                 let! crypto = portfolio.GetCrypto cmd.Token.Value cmd.UserId
                 crypto.DeleteTransaction(cmd.TransactionId)
                 do! portfolio.SaveCrypto crypto cmd.UserId
-                return ServiceResponse()
+                return Ok
         }
         
         member _.Handle(query:Details) = task {
@@ -247,11 +247,7 @@ namespace core.fs.Cryptos
                         |> Async.Sequential
                         |> Async.StartAsTask
                         
-                    let failures = commands |> Seq.filter (fun r -> r.IsOk = false)
-                    
-                    match failures |> Seq.isEmpty with
-                    | true -> return ServiceResponse()
-                    | false -> return ResponseUtils.failed (failures |> Seq.map (fun r -> r.Error.Message) |> String.concat "\n")
+                    return commands |> ResponseUtils.toOkOrConcatErrors
         }
         
         member this.Handle(cmd:ImportCoinbase) = task {
@@ -288,11 +284,7 @@ namespace core.fs.Cryptos
                         |> Async.Sequential
                         |> Async.StartAsTask
                         
-                    let failures = commands |> Seq.filter (fun r -> r.IsOk = false)
-                    
-                    match failures |> Seq.isEmpty with
-                    | true -> return ServiceResponse()
-                    | false -> return ResponseUtils.failed (failures |> Seq.map (fun r -> r.Error.Message) |> String.concat "\n")
+                    return commands |> ResponseUtils.toOkOrConcatErrors
         }
         
         member this.Handle(cmd:ImportCoinbasePro) = task {
@@ -331,7 +323,7 @@ namespace core.fs.Cryptos
                         |> Async.Sequential
                         |> Async.StartAsTask
                         
-                    return ServiceResponse()
+                    return Ok
         }
         
         member this.Handle(import:ImportCryptoCommand) =

--- a/src/core.fs/Notes/Handlers.fs
+++ b/src/core.fs/Notes/Handlers.fs
@@ -171,7 +171,7 @@ namespace core.fs.Notes
                         imports |> Seq.filter(fun r -> r.IsOk = false)
                         
                     match failedImports |> Seq.isEmpty with
-                    | true -> return ServiceResponse()
+                    | true -> return Ok
                     | false -> 
                         let failedImports = failedImports |> Seq.map(fun r -> r.Error.Message) |> String.concat "\n"
                         return failedImports |> ResponseUtils.failed

--- a/src/core.fs/Options/Handler.fs
+++ b/src/core.fs/Options/Handler.fs
@@ -173,11 +173,11 @@ type Handler(accounts: IAccountStorage, brokerage: IBrokerage, storage: IPortfol
             let! opt = storage.GetOwnedOption command.OptionId command.UserId
 
             match opt with
-            | null -> return ServiceResponse(ServiceError("Unable to find option do delete"))
+            | null -> return "Unable to find option do delete" |> ServiceError |> Error
             | _ ->
                 opt.Delete()
                 do! storage.SaveOwnedOption opt command.UserId
-                return ServiceResponse()
+                return Ok
         }
 
     member this.Handle(cmd: BuyOrSellCommand) =

--- a/src/core.fs/Options/Import.fs
+++ b/src/core.fs/Options/Import.fs
@@ -92,7 +92,7 @@ module Import =
                 
                 let finalResult =
                     match failed with
-                    | None -> ServiceResponse()
+                    | None -> Ok
                     | Some f -> f.Error.Message |> ResponseUtils.failed
                     
                 return finalResult

--- a/src/core.fs/Portfolio/Handler.fs
+++ b/src/core.fs/Portfolio/Handler.fs
@@ -186,7 +186,7 @@ type Handler(accounts:IAccountStorage,brokerage:IBrokerage,csvWriter:ICSVWriter,
             | Some stock ->
                 stock.DeletePosition(command.PositionId) |> ignore
                 do! storage.Save stock command.UserId
-                return ServiceResponse()
+                return Ok
     }
         
     member this.Handle (query:Query) = task {
@@ -233,7 +233,7 @@ type Handler(accounts:IAccountStorage,brokerage:IBrokerage,csvWriter:ICSVWriter,
                 | false -> ()
                 | true -> do! storage.Save stock command.UserId
                 
-                return ServiceResponse()
+                return Ok
     }
     
     member _.Handle (command:RemoveLabel) = task {
@@ -256,7 +256,7 @@ type Handler(accounts:IAccountStorage,brokerage:IBrokerage,csvWriter:ICSVWriter,
                 | false -> ()
                 | true -> do! storage.Save stock command.UserId
                 
-                return ServiceResponse()
+                return Ok
     }
     
     member _.Handle (command:AddLabel) = task {
@@ -279,7 +279,7 @@ type Handler(accounts:IAccountStorage,brokerage:IBrokerage,csvWriter:ICSVWriter,
                 | false -> ()
                 | true -> do! storage.Save stock command.UserId
                 
-                return ServiceResponse()
+                return Ok
     }
     
     member _.Handle (query:ProfitPointsQuery) = task {
@@ -343,7 +343,7 @@ type Handler(accounts:IAccountStorage,brokerage:IBrokerage,csvWriter:ICSVWriter,
                 
                 do! storage.Save stock command.UserId
                 
-                return ServiceResponse()
+                return Ok
     }
     
     member _.Handle (command:SimulateTrade) = task {

--- a/src/core.fs/Portfolio/ListsHandler.fs
+++ b/src/core.fs/Portfolio/ListsHandler.fs
@@ -232,5 +232,5 @@ type Handler(accounts:IAccountStorage, portfolio:IPortfolioStorage, csvWriter:IC
             | null -> return "List not found" |> ResponseUtils.failed
             | _ ->
                 do! portfolio.DeleteStockList list command.UserId
-                return ServiceResponse()
+                return Ok
     }

--- a/src/core.fs/Portfolio/PendingPositionsHandler.fs
+++ b/src/core.fs/Portfolio/PendingPositionsHandler.fs
@@ -96,7 +96,7 @@ type Handler(accounts:IAccountStorage,brokerage:IBrokerage,portfolio:IPortfolioS
                     
                     do! portfolio.SavePendingPosition position command.UserId
                 
-                    return ServiceResponse()
+                    return Ok
     }
     
     member this.Handle (command:Close) = task {
@@ -131,7 +131,7 @@ type Handler(accounts:IAccountStorage,brokerage:IBrokerage,portfolio:IPortfolioS
                 
                     do! portfolio.SavePendingPosition position command.UserId
                 
-                    return ServiceResponse()
+                    return Ok
     }
     
     member this.Handle (command:Export) = task {

--- a/src/core.fs/Stocks/Handlers.fs
+++ b/src/core.fs/Stocks/Handlers.fs
@@ -251,7 +251,7 @@ type Handler(accounts:IAccountStorage,brokerage:IBrokerage,secFilings:ISECFiling
                 
             | _ -> ()
             
-            return ServiceResponse()
+            return Ok
     }
     
     member _.Handle (query:DashboardQuery) = task {
@@ -312,7 +312,7 @@ type Handler(accounts:IAccountStorage,brokerage:IBrokerage,secFilings:ISECFiling
         | _ ->
             stock.Delete()
             do! portfolio.Save stock cmd.UserId
-            return ServiceResponse()
+            return Ok
     }
     
     member _.Handle (cmd:DeleteStop) = task {
@@ -322,7 +322,7 @@ type Handler(accounts:IAccountStorage,brokerage:IBrokerage,secFilings:ISECFiling
         | _ ->
             stock.DeleteStop()
             do! portfolio.Save stock cmd.UserId
-            return ServiceResponse()
+            return Ok
     }
     
     member _.Handle (cmd:DeleteTransaction) = task {
@@ -332,7 +332,7 @@ type Handler(accounts:IAccountStorage,brokerage:IBrokerage,secFilings:ISECFiling
         | _ ->
             stock.DeleteTransaction(cmd.TransactionId)
             do! portfolio.Save stock cmd.UserId
-            return ServiceResponse()
+            return Ok
     }
     
     member _.Handle (query:DetailsQuery) = task {
@@ -430,12 +430,7 @@ type Handler(accounts:IAccountStorage,brokerage:IBrokerage,secFilings:ISECFiling
                 |> Async.Sequential
                 |> Async.StartAsTask
                 
-            let failed =
-                results |> Seq.filter (fun x -> x.IsOk = false) |> Seq.map (fun x -> x.Error.Message) |> Seq.toArray
-                
-            match failed.Length with
-            | 0 -> return ServiceResponse()
-            | _ -> return String.Concat(failed, ",") |> ResponseUtils.failed
+            return results |> ResponseUtils.toOkOrConcatErrors
     }
     
     member _.Handle (query:OwnershipQuery) = task {
@@ -535,7 +530,7 @@ type Handler(accounts:IAccountStorage,brokerage:IBrokerage,secFilings:ISECFiling
         | _ ->
             stock.SetStop(cmd.StopPrice.Value) |> ignore
             do! portfolio.Save stock cmd.UserId
-            return ServiceResponse()
+            return Ok
     }
     
     

--- a/src/core/Shared/ServiceResponse.cs
+++ b/src/core/Shared/ServiceResponse.cs
@@ -1,17 +1,6 @@
 #nullable enable
 namespace core.Shared
 {
-    public class ServiceResponse
-    {
-        public ServiceError? Error { get; }
-
-        public ServiceResponse(ServiceError error) =>
-            Error = error;
-        public ServiceResponse() { }
-        
-        public bool IsOk => Error == null;
-    }
-
     public class ServiceResponse<TSuccess>
     {
         public TSuccess? Success { get; }

--- a/src/infrastructure/storage.shared/IOutbox.cs
+++ b/src/infrastructure/storage.shared/IOutbox.cs
@@ -8,5 +8,5 @@ namespace storage.shared;
 
 public interface IOutbox
 {
-    Task<ServiceResponse> AddEvents(List<AggregateEvent> e, IDbTransaction? tx);
+    Task<core.fs.Shared.ServiceResponse> AddEvents(List<AggregateEvent> e, IDbTransaction? tx);
 }

--- a/src/web/Utils/ControllerBaseExtensions.cs
+++ b/src/web/Utils/ControllerBaseExtensions.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using core.fs.Shared;
 using core.Shared;
 using core.Shared.Adapters.CSV;
 using Microsoft.AspNetCore.Mvc;
@@ -58,9 +59,10 @@ namespace web.Utils
             this ControllerBase controller,
             ServiceResponse r)
         {
-            if (r.Error != null)
+            if (r.IsError)
             {
-                return controller.Error(r.Error.Message);
+                var error = r as ServiceResponse.Error;
+                return controller.Error(error!.Item.Message);
             }
 
             return controller.Ok();

--- a/src/web/Utils/MediatRBasedOutbox.cs
+++ b/src/web/Utils/MediatRBasedOutbox.cs
@@ -13,7 +13,7 @@ public class IncompleteOutbox : IOutbox
     // but it was without any ability to handle failures etc and dependent on
     // mediatr. I might still use simple outbox that does not offer failure handling
     // but it will not be dependent on mediatr
-    public Task<ServiceResponse> AddEvents(List<AggregateEvent> e, IDbTransaction tx)
+    public Task<core.fs.Shared.ServiceResponse> AddEvents(List<AggregateEvent> e, IDbTransaction tx)
     {
         foreach (var @event in e)
         {
@@ -52,8 +52,8 @@ public class IncompleteOutbox : IOutbox
             //     _mediator.Publish(notification);
             // }
         }
-        
-        return Task.FromResult(new ServiceResponse());
+
+        return Task.FromResult(core.fs.Shared.ServiceResponse.Ok);
     }
 }
 

--- a/tests/storagetests/FakeMediator.cs
+++ b/tests/storagetests/FakeMediator.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Data;
 using System.Threading.Tasks;
+using core.fs.Shared;
 using core.Shared;
 using storage.shared;
 
@@ -10,7 +11,7 @@ namespace storagetests
     {
         public Task<ServiceResponse> AddEvents(List<AggregateEvent> e, IDbTransaction tx)
         {
-            return Task.FromResult(new ServiceResponse());
+            return Task.FromResult(ServiceResponse.Ok);
         }
     }
 }


### PR DESCRIPTION
Taking advantage of F# Ok/Error types that are used to indicate if the operation was successful or failed. This will eliminate the need of my own type, no need to reinvent the wheel.

Starting with just ServiceResult, ServiceResult<'a> will be next.