### PR TITLE
Remove implicit string conversion for Ticker type

### DIFF
--- a/src/core.fs/Helpers.fs
+++ b/src/core.fs/Helpers.fs
@@ -1,20 +1,21 @@
 namespace core.fs
 
 open System.Collections.Generic
+open core.Shared
 open core.Stocks
 open core.fs.Shared
 open core.fs.Shared.Adapters.Brokerage
 
 module Helpers =
 
-    let getViolations brokeragePositions localPositions (prices:Dictionary<string,StockQuote>) =
+    let getViolations brokeragePositions localPositions (prices:Dictionary<Ticker,StockQuote>) =
         
         let brokerageSideViolations =
             brokeragePositions
             |> Seq.map( fun (brokeragePosition:StockPosition) ->
                 
                 let currentPrice =
-                    match prices.TryGetValue(brokeragePosition.Ticker.Value) with
+                    match prices.TryGetValue(brokeragePosition.Ticker) with
                     | true, price -> price.Price
                     | false, _ -> 0m
                     

--- a/src/core.fs/Notes/Handlers.fs
+++ b/src/core.fs/Notes/Handlers.fs
@@ -112,7 +112,7 @@ namespace core.fs.Notes
             | None -> return "User not found" |> ResponseUtils.failedTyped<NotesView>
             | _ -> 
                 let! notes = portfolio.GetNotes(userId=command.UserId)
-                return NotesView(notes |> Seq.filter(fun n -> n.State.RelatedToTicker = command.Ticker.Value)) |> ResponseUtils.success<NotesView>
+                return NotesView(notes |> Seq.filter(fun n -> n.State.RelatedToTicker.Equals(command.Ticker))) |> ResponseUtils.success<NotesView>
         }
         
         member _.Handle (command: UpdateNote) = task {

--- a/src/core.fs/Portfolio/Handler.fs
+++ b/src/core.fs/Portfolio/Handler.fs
@@ -505,7 +505,7 @@ type Handler(accounts:IAccountStorage,brokerage:IBrokerage,csvWriter:ICSVWriter,
             let prices =
                 match pricesResponse.IsOk with
                 | true -> pricesResponse.Success
-                | false -> Dictionary<string, StockQuote>()
+                | false -> Dictionary<Ticker, StockQuote>()
                 
             positions |> Array.iter (fun p ->
                 match prices.TryGetValue(p.Ticker) with

--- a/src/core.fs/Portfolio/PendingPositionsHandler.fs
+++ b/src/core.fs/Portfolio/PendingPositionsHandler.fs
@@ -169,7 +169,7 @@ type Handler(accounts:IAccountStorage,brokerage:IBrokerage,portfolio:IPortfolioS
             let! priceResponse = brokerage.GetQuotes user.State tickers
             let prices =
                 match priceResponse.IsOk with
-                | false -> Dictionary<string, StockQuote>()
+                | false -> Dictionary<Ticker, StockQuote>()
                 | true -> priceResponse.Success
                 
             let dataWithPrices =

--- a/src/core.fs/Portfolio/Views.fs
+++ b/src/core.fs/Portfolio/Views.fs
@@ -305,7 +305,7 @@ type TransactionsView(transactions:Transaction seq, groupBy:string, tickers:Tick
     
     let groupByValue (groupBy:string) (t:Transaction) =
         match groupBy with
-        | "ticker" -> t.Ticker
+        | "ticker" -> t.Ticker.Value
         | "week" -> t.DateAsDate.AddDays(- float t.DateAsDate.DayOfWeek+1.0).ToString("MMMM dd, yyyy")
         | _ -> t.DateAsDate.ToString("MMMM, yyyy")
         

--- a/src/core.fs/Reports/Handlers.fs
+++ b/src/core.fs/Reports/Handlers.fs
@@ -107,7 +107,7 @@ type OutcomesReportForPositionsQuery =
 
 type OutcomesReportViewTickerCountPair =
     {
-        Ticker: string
+        Ticker: Ticker
         Count: int
     }
     
@@ -177,7 +177,7 @@ type SellView =
         | false -> 0m
         | true -> (this.CurrentPrice.Value - this.Price) / this.Price
     
-type SellsView(stocks:OwnedStock seq,prices:Dictionary<string,StockQuote>) =
+type SellsView(stocks:OwnedStock seq,prices:Dictionary<Ticker,StockQuote>) =
     
     member _.Sells: SellView seq =
         stocks
@@ -342,7 +342,7 @@ type Handler(accounts:IAccountStorage,brokerage:IBrokerage,marketHours:IMarketHo
                                 let lastPrice = priceResponse.Success[priceResponse.Success.Length - 1].Close
                                 MultipleBarPriceAnalysis.Run lastPrice priceResponse.Success
                         
-                        let tickerOutcome:TickerOutcomes = {outcomes=outcomes; ticker=t.Value}
+                        let tickerOutcome:TickerOutcomes = {outcomes=outcomes; ticker=t}
                         
                         let gapsView =
                             match query.IncludeGapAnalysis with
@@ -352,7 +352,7 @@ type Handler(accounts:IAccountStorage,brokerage:IBrokerage,marketHours:IMarketHo
                             | false -> None
                             
                         let patterns = PatternDetection.generate priceResponse.Success
-                        let tickerPatterns = {patterns = patterns; ticker = t.Value}
+                        let tickerPatterns = {patterns = patterns; ticker = t}
                         
                         return Some (tickerOutcome, gapsView, tickerPatterns)
                     }
@@ -420,8 +420,8 @@ type Handler(accounts:IAccountStorage,brokerage:IBrokerage,marketHours:IMarketHo
                         
                         // TODO: bring back orders once we migrate position analysis to f#
                         let outcomes = PositionAnalysis.generate position priceResponse.Success orders
-                        let tickerOutcome:TickerOutcomes = {outcomes = outcomes; ticker = position.Ticker.Value}
-                        let tickerPatterns = {patterns = PatternDetection.generate priceResponse.Success; ticker = position.Ticker.Value}
+                        let tickerOutcome:TickerOutcomes = {outcomes = outcomes; ticker = position.Ticker}
+                        let tickerPatterns = {patterns = PatternDetection.generate priceResponse.Success; ticker = position.Ticker}
                         
                         return Some (tickerOutcome, tickerPatterns)
                     }
@@ -486,7 +486,7 @@ type Handler(accounts:IAccountStorage,brokerage:IBrokerage,marketHours:IMarketHo
             
             let prices =
                 match priceResult.IsOk with
-                | false -> Dictionary<string,StockQuote>()
+                | false -> Dictionary<Ticker,StockQuote>()
                 | true -> priceResult.Success
                 
             let response = SellsView(stocks, prices)

--- a/src/core.fs/Services/Analysis.fs
+++ b/src/core.fs/Services/Analysis.fs
@@ -1,6 +1,7 @@
 namespace core.fs.Services.Analysis
 
 open System.Collections.Generic
+open core.Shared
 open core.fs.Shared
 open core.fs.Shared.Adapters.Stocks
 
@@ -19,7 +20,7 @@ type AnalysisOutcome(key:string, outcomeType:string, value:decimal, valueType:Va
 type TickerOutcomes =
     {
         outcomes: seq<AnalysisOutcome>
-        ticker:string
+        ticker:Ticker
     }
     
 type AnalysisOutcomeEvaluation(name:string,``type``:string,sortColumn:string,matchingTickers:seq<TickerOutcomes>) =
@@ -40,7 +41,7 @@ type Pattern =
 type TickerPatterns =
     {
         patterns: seq<Pattern>
-        ticker:string
+        ticker:Ticker
     }
     
 type SMA(values,interval) =
@@ -93,7 +94,7 @@ type SMAContainer(sma20,sma50,sma150,sma200) =
 module AnalysisOutcomeEvaluationScoringHelper =
     
     let generateTickerCounts evaluations =
-        let counts = Dictionary<string, int>()
+        let counts = Dictionary<Ticker, int>()
         
         evaluations
         |> Seq.iter (fun (category:AnalysisOutcomeEvaluation) ->

--- a/src/core.fs/Services/CSVExport.fs
+++ b/src/core.fs/Services/CSVExport.fs
@@ -285,7 +285,7 @@ module CSVExport =
             |> Seq.map (fun n ->
                 {
                     Created = n.State.Created.ToString(DATE_FORMAT)
-                    Ticker = n.State.RelatedToTicker
+                    Ticker = n.State.RelatedToTicker.Value
                     Note = n.State.Note
                 }
             )

--- a/src/core.fs/Shared/Adapters/Brokerage.fs
+++ b/src/core.fs/Shared/Adapters/Brokerage.fs
@@ -215,7 +215,7 @@ type IBrokerage =
     abstract member CancelOrder : state:UserState -> orderId:string -> Task<ServiceResponse<bool>>
     abstract member GetPriceHistory : state:UserState -> ticker:Ticker -> frequency:PriceFrequency -> start:DateTimeOffset -> ``end``:DateTimeOffset -> Task<ServiceResponse<PriceBar[]>>
     abstract member GetQuote : state:UserState -> ticker:Ticker -> Task<ServiceResponse<StockQuote>>
-    abstract member GetQuotes : state:UserState -> tickers:Ticker seq -> Task<ServiceResponse<Dictionary<string, StockQuote>>>
+    abstract member GetQuotes : state:UserState -> tickers:Ticker seq -> Task<ServiceResponse<Dictionary<Ticker, StockQuote>>>
     abstract member GetMarketHours : state:UserState -> start:DateTimeOffset -> Task<ServiceResponse<MarketHours>>
     abstract member Search : state:UserState -> query:string -> limit:int -> Task<ServiceResponse<SearchResult[]>>
     abstract member GetOptions : state:UserState -> ticker:Ticker -> expirationDate:DateTimeOffset option -> strikePrice:decimal option -> contractType:string option -> Task<ServiceResponse<OptionChain>>

--- a/src/core.fs/Shared/Adapters/SEC.fs
+++ b/src/core.fs/Shared/Adapters/SEC.fs
@@ -26,7 +26,7 @@ type CompanyFiling =
         member this.IsNew = this.FilingDate > System.DateTime.Now.AddDays(-7)
 
 [<Struct>]
-type CompanyFilings(ticker:string, filings:seq<CompanyFiling>) =
+type CompanyFilings(ticker:Ticker, filings:seq<CompanyFiling>) =
     member _.Ticker = ticker
     member _.Filings = filings
 

--- a/src/core.fs/Stocks/Handlers.fs
+++ b/src/core.fs/Stocks/Handlers.fs
@@ -280,7 +280,7 @@ type Handler(accounts:IAccountStorage,brokerage:IBrokerage,secFilings:ISECFiling
             
             let prices =
                 match quotesResponse.IsOk with
-                | false -> Dictionary<string,StockQuote>()
+                | false -> Dictionary<Ticker,StockQuote>()
                 | true -> quotesResponse.Success
                 
             let violations =

--- a/src/core/Cryptos/CryptoTransaction.cs
+++ b/src/core/Cryptos/CryptoTransaction.cs
@@ -55,8 +55,8 @@ namespace core.Cryptos
         }
 
         public Transaction ToSharedTransaction() => Credit switch {
-            > 0 => Transaction.NonPLTx(AggregateId, TransactionId, Token, Description, Price, Credit, When, isOption: false),
-            _ => Transaction.NonPLTx(AggregateId, TransactionId, Token, Description, Price, Debit, When, isOption: false)
+            > 0 => Transaction.NonPLTx(AggregateId, TransactionId, new Ticker(Token), Description, Price, Credit, When, isOption: false),
+            _ => Transaction.NonPLTx(AggregateId, TransactionId, new Ticker(Token), Description, Price, Debit, When, isOption: false)
         };
     }
 }

--- a/src/core/Notes/Note.cs
+++ b/src/core/Notes/Note.cs
@@ -34,7 +34,7 @@ namespace core.Notes
                     created,
                     userId,
                     note,
-                    ticker
+                    ticker.Value
                 )
             );
         }
@@ -46,7 +46,7 @@ namespace core.Notes
                 return true;
             }
 
-            return State.RelatedToTicker == filter.Value;
+            return State.RelatedToTicker.Equals(filter.Value);
         }
 
         public void Update(string note)

--- a/src/core/Notes/NoteState.cs
+++ b/src/core/Notes/NoteState.cs
@@ -6,7 +6,7 @@ namespace core.Notes
     public class NoteState : IAggregateState
     {
         public Guid Id { get; internal set; }
-        public string RelatedToTicker { get; internal set; }
+        public Ticker RelatedToTicker { get; internal set; }
         public DateTimeOffset Created { get; internal set; }
         public string Note { get; internal set; }
         public Guid UserId { get; internal set; }
@@ -57,7 +57,7 @@ namespace core.Notes
         {
             Id = c.AggregateId;
             UserId = c.UserId;
-            RelatedToTicker = c.Ticker;
+            RelatedToTicker = new Ticker(c.Ticker);
             Created = c.When;
             Note = c.Note;
         }

--- a/src/core/Options/OwnedOption.cs
+++ b/src/core/Options/OwnedOption.cs
@@ -41,7 +41,7 @@ namespace core.Options
                  Guid.NewGuid(),
                  Guid.NewGuid(),
                  DateTimeOffset.UtcNow,
-                 ticker,
+                 ticker.Value,
                  strikePrice,
                  type,
                  expiration.Date,
@@ -59,7 +59,7 @@ namespace core.Options
              );
          }
  
-         public bool IsMatch(string ticker, decimal strike, OptionType type, DateTimeOffset expiration)
+         public bool IsMatch(Ticker ticker, decimal strike, OptionType type, DateTimeOffset expiration)
              => State.IsMatch(ticker, strike, type, expiration);
  
          public void Buy(int numberOfContracts, decimal premium, DateTimeOffset filled, string notes)

--- a/src/core/Options/OwnedOptionState.cs
+++ b/src/core/Options/OwnedOptionState.cs
@@ -164,16 +164,16 @@ namespace core.Options
         internal void ApplyInternal(OptionOpened opened)
         {
             Id = opened.AggregateId;
-            Ticker = opened.Ticker;
+            Ticker = new Ticker(opened.Ticker);
             StrikePrice = opened.StrikePrice;
             Expiration = opened.Expiration;
             OptionType = opened.OptionType;
             UserId = opened.UserId;
         }
 
-        internal bool IsMatch(string ticker, decimal strike, OptionType type, DateTimeOffset expiration)
+        internal bool IsMatch(Ticker ticker, decimal strike, OptionType type, DateTimeOffset expiration)
         {
-            return Ticker == ticker 
+            return Ticker.Equals(ticker) 
                 && StrikePrice == strike 
                 && OptionType == type 
                 && Expiration.Date == expiration.Date;

--- a/src/core/Portfolio/PendingStockPosition.cs
+++ b/src/core/Portfolio/PendingStockPosition.cs
@@ -54,7 +54,7 @@ namespace core.Portfolio
                 Guid.NewGuid(),
                 when: DateTimeOffset.UtcNow,
                 userId: userId,
-                ticker: ticker,
+                ticker: ticker.Value,
                 price: price,
                 numberOfShares: numberOfShares,
                 stopPrice: stopPrice,

--- a/src/core/Portfolio/StockList.cs
+++ b/src/core/Portfolio/StockList.cs
@@ -42,24 +42,24 @@ namespace core.Portfolio
 
         public void AddStock(Ticker ticker, string note)
         {
-            var exists = State.Tickers.Exists(x => x.Ticker == ticker);
+            var exists = State.Tickers.Exists(x => x.Ticker.Equals(ticker));
             if (exists)
             {
                 return;
             }
             
-            Apply(new StockListTickerAdded(Guid.NewGuid(), State.Id, DateTimeOffset.UtcNow, note, ticker));
+            Apply(new StockListTickerAdded(Guid.NewGuid(), State.Id, DateTimeOffset.UtcNow, note, ticker.Value));
         }
 
         public void RemoveStock(Ticker ticker)
         {
-            var exists = State.Tickers.Exists(x => x.Ticker == ticker);
+            var exists = State.Tickers.Exists(x => x.Ticker.Equals(ticker));
             if (!exists)
             {
                 throw new InvalidOperationException("Ticker does not exist in the list");
             }
 
-            Apply(new StockListTickerRemoved(Guid.NewGuid(), State.Id, DateTimeOffset.UtcNow, ticker));
+            Apply(new StockListTickerRemoved(Guid.NewGuid(), State.Id, DateTimeOffset.UtcNow, ticker.Value));
         }
 
         public void AddTag(string tag)

--- a/src/core/Shared/Ticker.cs
+++ b/src/core/Shared/Ticker.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace core.Shared
 {
-    public struct Ticker : IComparable
+    public struct Ticker : IComparable, IEquatable<Ticker>
     {
         private readonly string _ticker;
 
@@ -15,9 +15,6 @@ namespace core.Shared
             _ticker = ticker.ToUpper();
         }
 
-        public static implicit operator string(Ticker t) => t._ticker;
-        public static implicit operator Ticker(string t) => new Ticker(t);
-
         public string Value => _ticker;
         public int CompareTo(object obj)
         {
@@ -27,6 +24,23 @@ namespace core.Shared
             }
 
             return -1;
+        }
+
+        public override string ToString() => _ticker;
+
+        public bool Equals(Ticker other)
+        {
+            return _ticker == other._ticker;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is Ticker other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return (_ticker != null ? _ticker.GetHashCode() : 0);
         }
     }
 }

--- a/src/core/Shared/Transaction.cs
+++ b/src/core/Shared/Transaction.cs
@@ -6,7 +6,7 @@ namespace core.Shared
     {
         public Guid AggregateId { get; }
         public Guid EventId { get; }
-        public string Ticker { get; }
+        public Ticker Ticker { get; }
         public string Description { get; }
         public decimal Price { get; set; }
         public decimal Amount { get; }
@@ -19,7 +19,7 @@ namespace core.Shared
         private Transaction(
             Guid aggregateId,
             Guid eventId,
-            string ticker,
+            Ticker ticker,
             string description,
             decimal price,
             decimal amount,
@@ -38,12 +38,12 @@ namespace core.Shared
             IsPL = isPL;
         }
 
-        public static Transaction NonPLTx(Guid aggregateId, Guid eventId, string ticker, string description, decimal price, decimal amount, DateTimeOffset when, bool isOption)
+        public static Transaction NonPLTx(Guid aggregateId, Guid eventId, Ticker ticker, string description, decimal price, decimal amount, DateTimeOffset when, bool isOption)
         {
             return new Transaction(aggregateId, eventId, ticker, description, price, amount, when, isOption, false);
         }
 
-        public static Transaction PLTx(Guid aggregateId, string ticker, string description, decimal price, decimal amount, DateTimeOffset when, bool isOption)
+        public static Transaction PLTx(Guid aggregateId, Ticker ticker, string description, decimal price, decimal amount, DateTimeOffset when, bool isOption)
         {
             return new Transaction(aggregateId, Guid.Empty, ticker, description, price, amount, when, isOption, true);
         }

--- a/src/core/Stocks/OwnedStock.cs
+++ b/src/core/Stocks/OwnedStock.cs
@@ -18,7 +18,7 @@ namespace core.Stocks
                 throw new InvalidOperationException("Missing user id");
             }
 
-            Apply(new TickerObtained(Guid.NewGuid(), Guid.NewGuid(), DateTimeOffset.UtcNow, ticker, userId));
+            Apply(new TickerObtained(Guid.NewGuid(), Guid.NewGuid(), DateTimeOffset.UtcNow, ticker.Value, userId));
         }
 
         public void Purchase(decimal numberOfShares, decimal price, DateTimeOffset date, string notes = null, decimal? stopPrice = null)
@@ -39,7 +39,7 @@ namespace core.Stocks
                     State.Id,
                     date,
                     State.UserId,
-                    State.Ticker,
+                    State.Ticker.Value,
                     numberOfShares,
                     price,
                     notes,
@@ -61,7 +61,7 @@ namespace core.Stocks
                     State.Id,
                     DateTimeOffset.UtcNow,
                     State.UserId,
-                    State.Ticker
+                    State.Ticker.Value
                 )
             );
         }
@@ -100,7 +100,7 @@ namespace core.Stocks
             }
 
             Apply(
-                new StopPriceSet(Guid.NewGuid(), State.Id, DateTimeOffset.UtcNow, State.UserId, State.Ticker, stopPrice)
+                new StopPriceSet(Guid.NewGuid(), State.Id, DateTimeOffset.UtcNow, State.UserId, State.Ticker.Value, stopPrice)
             );
 
             return true;
@@ -189,7 +189,7 @@ namespace core.Stocks
                     State.Id,
                     date,
                     State.UserId,
-                    State.Ticker,
+                    State.Ticker.Value,
                     numberOfShares,
                     price,
                     notes)

--- a/src/core/Stocks/OwnedStockState.cs
+++ b/src/core/Stocks/OwnedStockState.cs
@@ -26,7 +26,7 @@ namespace core.Stocks
         internal void ApplyInternal(TickerObtained o)
         {
             Id = o.AggregateId;
-            Ticker = o.Ticker;
+            Ticker = new Ticker(o.Ticker);
             UserId = o.UserId;
         }
 
@@ -74,7 +74,7 @@ namespace core.Stocks
 
             if (OpenPosition == null)
             {
-                OpenPosition = new PositionInstance(_positionId, purchased.Ticker, purchased.When);
+                OpenPosition = new PositionInstance(_positionId, new Ticker(purchased.Ticker), purchased.When);
                 Positions.Add(OpenPosition);
                 _positionId++;
             }

--- a/src/infrastructure/secedgar/EdgarClient.cs
+++ b/src/infrastructure/secedgar/EdgarClient.cs
@@ -23,7 +23,7 @@ public class EdgarClient : ISECFilings
         try
         {
             var results = await EdgarSearch.CreateAsync(
-                stock_symbol: symbol,
+                stock_symbol: symbol.Value,
                 results_per_page: EdgarSearchResultsPerPage.Entries10
             );
 

--- a/src/infrastructure/storage.shared/PortfolioStorage.cs
+++ b/src/infrastructure/storage.shared/PortfolioStorage.cs
@@ -48,7 +48,7 @@ namespace storage.shared
         {
             var stocks = await GetStocks(userId);
             
-            return stocks.SingleOrDefault(s => s.State.Ticker == ticker.Value);
+            return stocks.SingleOrDefault(s => s.State.Ticker.Equals(ticker));
         }
 
         public async Task<OwnedStock> GetStockByStockId(Guid stockId, UserId userId)

--- a/src/web/BackgroundServices/EmailNotificationService.cs
+++ b/src/web/BackgroundServices/EmailNotificationService.cs
@@ -8,6 +8,7 @@ using core.fs.Shared;
 using core.fs.Shared.Adapters.Brokerage;
 using core.fs.Shared.Adapters.Email;
 using core.fs.Shared.Adapters.Storage;
+using core.Shared;
 using Microsoft.Extensions.Logging;
 
 namespace web.BackgroundServices;
@@ -156,7 +157,7 @@ public class EmailNotificationService : GenericBackgroundServiceHost
         return ToEmailRow(valueFormat, triggeredValue, ticker, description, sourceList, _marketHours.ToMarketTime(time));
     }
 
-    public static object ToEmailRow(ValueFormat valueFormat, decimal triggeredValue, string ticker, string description, string sourceList, DateTimeOffset time)
+    public static object ToEmailRow(ValueFormat valueFormat, decimal triggeredValue, Ticker ticker, string description, string sourceList, DateTimeOffset time)
     {
         string FormattedValue()
         {
@@ -172,7 +173,7 @@ public class EmailNotificationService : GenericBackgroundServiceHost
 
         return new
         {
-            ticker,
+            ticker = ticker.Value,
             value = FormattedValue(),
             description,
             sourceList,

--- a/src/web/BackgroundServices/StockAlertService.cs
+++ b/src/web/BackgroundServices/StockAlertService.cs
@@ -24,7 +24,7 @@ namespace web.BackgroundServices
         private readonly ILogger<StockAlertService> _logger;
         private readonly IMarketHours _marketHours;
         private readonly IPortfolioStorage _portfolio;
-        private readonly Dictionary<string, ServiceResponse<PriceBar[]>> _priceCache = new();
+        private readonly Dictionary<Ticker, ServiceResponse<PriceBar[]>> _priceCache = new();
         
         public StockAlertService(
             IAccountStorage accounts,

--- a/src/web/BackgroundServices/WeeklyUpsideReversalService.cs
+++ b/src/web/BackgroundServices/WeeklyUpsideReversalService.cs
@@ -32,7 +32,7 @@ public class WeeklyUpsideReversalService : GenericBackgroundServiceHost
     private readonly IMarketHours _marketHours;
 
     private readonly Dictionary<UserState, HashSet<Ticker>> _tickersToCheck = new();
-    private readonly Dictionary<UserState, List<(string Ticker, Pattern Pattern)>> _patternsDiscovered = new();
+    private readonly Dictionary<UserState, List<(Ticker Ticker, Pattern Pattern)>> _patternsDiscovered = new();
 
     private Func<CancellationToken, Task> _toRun;
     private Func<TimeSpan> _sleepCalculation;
@@ -168,9 +168,9 @@ public class WeeklyUpsideReversalService : GenericBackgroundServiceHost
                     continue;
                 }
 
-                if (!_patternsDiscovered.TryGetValue(u.Key, out List<(string Ticker, Pattern Pattern)> value))
+                if (!_patternsDiscovered.TryGetValue(u.Key, out List<(Ticker Ticker, Pattern Pattern)> value))
                 {
-                    value = new List<(string, Pattern)>();
+                    value = new List<(Ticker, Pattern)>();
                     _patternsDiscovered[u.Key] = value;
                 }
 

--- a/src/web/Controllers/OptionsController.cs
+++ b/src/web/Controllers/OptionsController.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using core.fs.Options;
+using core.Shared;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -27,7 +28,7 @@ namespace web.Controllers
             this.OkOrError(
                 _service.Handle(
                     new ChainQuery(
-                        ticker: ticker, userId: User.Identifier()
+                        ticker: new Ticker(ticker), userId: User.Identifier()
                     )
                 )
             );

--- a/src/web/Controllers/PortfolioController.cs
+++ b/src/web/Controllers/PortfolioController.cs
@@ -169,7 +169,7 @@ namespace web.Controllers
                         show: show,
                         groupBy: groupBy,
                         txType: txType,
-                        ticker: ticker)
+                        ticker: new Ticker(ticker))
                 )
             );
 
@@ -218,7 +218,7 @@ namespace web.Controllers
             this.OkOrError(
                 service.Handle(
                     new SimulateTrade(
-                        ticker: ticker,
+                        ticker: new Ticker(ticker),
                         positionId: positionId, 
                         userId: User.Identifier()
                     )
@@ -257,7 +257,7 @@ namespace web.Controllers
             this.OkOrError(
                 handler.Handle(
                     new DeletePosition(
-                        ticker: ticker,
+                        ticker: new Ticker(ticker),
                         positionId: positionId,
                         userId: User.Identifier()
                     )
@@ -281,7 +281,7 @@ namespace web.Controllers
             this.OkOrError(
                 handler.Handle(
                     new RemoveLabel(
-                        ticker: ticker,
+                        ticker: new Ticker(ticker),
                         positionId: positionId,
                         key: label,
                         userId: User.Identifier()

--- a/src/web/Controllers/ReportsController.cs
+++ b/src/web/Controllers/ReportsController.cs
@@ -55,7 +55,7 @@ namespace web.Controllers
 
         [HttpGet("gaps/tickers/{ticker}")]
         public Task<ActionResult> TickerGaps(string ticker, [FromQuery] string frequency)
-            => this.OkOrError(_service.Handle(new GapReportQuery(User.Identifier(), ticker, PriceFrequency.FromString(frequency))));
+            => this.OkOrError(_service.Handle(new GapReportQuery(User.Identifier(), new Ticker(ticker), PriceFrequency.FromString(frequency))));
 
         [HttpGet("positions")]
         public Task<ActionResult> Portfolio() =>
@@ -63,6 +63,6 @@ namespace web.Controllers
 
         [HttpGet("DailyPositionReport/{ticker}/{positionId}")]
         public Task<ActionResult> DailyPositionReport(string ticker, int positionId) =>
-            this.OkOrError(_service.Handle(new DailyPositionReportQuery(User.Identifier(), ticker, positionId)));
+            this.OkOrError(_service.Handle(new DailyPositionReportQuery(User.Identifier(), new Ticker(ticker), positionId)));
     }
 }

--- a/src/web/Controllers/StocksController.cs
+++ b/src/web/Controllers/StocksController.cs
@@ -24,11 +24,11 @@ namespace web.Controllers
         public Task<ActionResult> Dashboard() => this.OkOrError(_service.Handle(new DashboardQuery(User.Identifier())));
 
         [HttpGet("{ticker}")]
-        public Task<ActionResult> Details([FromRoute]string ticker) => this.OkOrError(_service.Handle(new DetailsQuery(ticker, User.Identifier())));
+        public Task<ActionResult> Details([FromRoute]string ticker) => this.OkOrError(_service.Handle(new DetailsQuery(new Ticker(ticker), User.Identifier())));
 
         [HttpGet("{ticker}/prices")]
         public Task<ActionResult> Prices([FromRoute]string ticker, [FromQuery] int numberOfDays) =>
-            this.OkOrError(_service.Handle(PricesQuery.NumberOfDays(numberOfDays, ticker, User.Identifier())));
+            this.OkOrError(_service.Handle(PricesQuery.NumberOfDays(numberOfDays, new Ticker(ticker), User.Identifier())));
 
         [HttpGet("{ticker}/secfilings")]
         public Task<ActionResult> SecFilings([FromRoute] string ticker) =>

--- a/src/web/Startup.cs
+++ b/src/web/Startup.cs
@@ -46,7 +46,6 @@ namespace web
                     {
                         if (type.IsSubclassOf(typeof(JsonConverter)))
                         {
-                            Console.WriteLine($"Converter: {type}");
                             var converter = Activator.CreateInstance(type);
                             o.JsonSerializerOptions.Converters.Add((JsonConverter)converter);
                         }

--- a/tests/coretests/Notes/NoteTests.cs
+++ b/tests/coretests/Notes/NoteTests.cs
@@ -1,6 +1,7 @@
 using System;
 using core.Notes;
 using core.Shared;
+using coretests.testdata;
 using Xunit;
 
 namespace coretests.Notes
@@ -21,7 +22,7 @@ namespace coretests.Notes
             return new Note(
                 Guid.NewGuid(),
                 "description",
-                "tsla",
+                TestDataGenerator.TSLA,
                 DateTimeOffset.UtcNow
             );
         }
@@ -47,25 +48,25 @@ namespace coretests.Notes
         [Fact]
         public void Ticker()
         {
-            Assert.Equal("TSLA", _state.RelatedToTicker);
+            Assert.Equal(TestDataGenerator.TSLA, _state.RelatedToTicker);
         }
 
         [Fact]
         public void FailWithEmptyUser()
         {
-            Assert.Throws<InvalidOperationException>(() => new Note(Guid.Empty, "some note", "ticker", DateTimeOffset.UtcNow));
+            Assert.Throws<InvalidOperationException>(() => new Note(Guid.Empty, "some note", TestDataGenerator.TSLA, DateTimeOffset.UtcNow));
         }
 
         [Fact]
         public void FailWithNoNote()
         {
-            Assert.Throws<InvalidOperationException>(() => new Note(Guid.NewGuid(), "", "ticker", DateTimeOffset.UtcNow));
+            Assert.Throws<InvalidOperationException>(() => new Note(Guid.NewGuid(), "", TestDataGenerator.TSLA, DateTimeOffset.UtcNow));
         }
 
         [Fact]
         public void FailWithFutureCreated()
         {
-            Assert.Throws<InvalidOperationException>(() => new Note(Guid.NewGuid(), "note", "ticker", DateTimeOffset.UtcNow.AddDays(1)));
+            Assert.Throws<InvalidOperationException>(() => new Note(Guid.NewGuid(), "note", TestDataGenerator.TSLA, DateTimeOffset.UtcNow.AddDays(1)));
         }
 
         [Fact]
@@ -91,9 +92,7 @@ namespace coretests.Notes
         {
             var note = CreateTestNote();
 
-            Ticker t = new Ticker(note.State.RelatedToTicker);
-
-            Assert.True(note.MatchesTickerFilter(t));
+            Assert.True(note.MatchesTickerFilter(note.State.RelatedToTicker));
         }
     }
 }

--- a/tests/coretests/Options/DashboardTests.cs
+++ b/tests/coretests/Options/DashboardTests.cs
@@ -41,8 +41,8 @@ namespace coretests.Options
             var brokerage = new Mock<IBrokerage>();
             brokerage.Setup(x => x.GetQuotes(It.IsAny<UserState>(), It.IsAny<List<Ticker>>()))
                 .Returns(Task.FromResult(
-                    new ServiceResponse<Dictionary<string, StockQuote>>(
-                        new Dictionary<string, StockQuote>()
+                    new ServiceResponse<Dictionary<Ticker, StockQuote>>(
+                        new Dictionary<Ticker, StockQuote>()
                     )
                 ));
 

--- a/tests/coretests/Options/OwnedOptionStatsTests.cs
+++ b/tests/coretests/Options/OwnedOptionStatsTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using core.fs.Options;
 using core.Options;
+using coretests.testdata;
 using Xunit;
 using OptionType = core.Options.OptionType;
 
@@ -13,12 +14,12 @@ namespace coretests.Options
         public OwnedOptionStatsTests()
         {
             var userId = Guid.NewGuid();
-            var soldOption1 = new OwnedOption("AMD", 45, OptionType.CALL, new DateTimeOffset(2019, 10, 10, 0, 0, 0, TimeSpan.Zero), userId);
+            var soldOption1 = new OwnedOption(TestDataGenerator.TSLA, 45, OptionType.CALL, new DateTimeOffset(2019, 10, 10, 0, 0, 0, TimeSpan.Zero), userId);
             soldOption1.Sell(1, 10, DateTimeOffset.Parse("2019-10-10"), null);
             soldOption1.Expire(assign: true);
             var o1 = new OwnedOptionView(soldOption1.State, optionDetail: null);
 
-            var soldOption2 = new OwnedOption("AMD", 45, OptionType.CALL, new DateTimeOffset(2019, 10, 10, 0, 0, 0, TimeSpan.Zero), userId);
+            var soldOption2 = new OwnedOption(TestDataGenerator.TSLA, 45, OptionType.CALL, new DateTimeOffset(2019, 10, 10, 0, 0, 0, TimeSpan.Zero), userId);
             soldOption2.Sell(1, 150, DateTimeOffset.Parse("2019-10-10"), null);
             soldOption2.Buy(1, 100, DateTimeOffset.Parse("2019-10-10"), null);
             var o2 = new OwnedOptionView(soldOption2.State, optionDetail: null);

--- a/tests/coretests/Options/OwnedOptionTests.cs
+++ b/tests/coretests/Options/OwnedOptionTests.cs
@@ -128,7 +128,7 @@ namespace coretests.Options
         {
             var option = GetTestOption(_expiration);
 
-            option.IsMatch("TEUM", 2.5m, OptionType.PUT, _expiration);
+            option.IsMatch(new Ticker("TEUM"), 2.5m, OptionType.PUT, _expiration);
         }
 
         [Theory]
@@ -137,7 +137,7 @@ namespace coretests.Options
         public void CreateWithBadTickerFails(string ticker, decimal strikePrice)
         {
             Assert.Throws<InvalidOperationException>( () =>
-                new OwnedOption(ticker, strikePrice, OptionType.CALL, DateTimeOffset.UtcNow, Guid.NewGuid()));
+                new OwnedOption(new Ticker(ticker), strikePrice, OptionType.CALL, DateTimeOffset.UtcNow, Guid.NewGuid()));
         }
 
         [Fact]
@@ -195,7 +195,7 @@ namespace coretests.Options
             decimal strikePrice = 2.5m)
         {
             var option = new OwnedOption(
-                ticker,
+                new Ticker(ticker),
                 strikePrice,
                 optionType,
                 expiration,

--- a/tests/coretests/Portfolio/PendingStockPositionTests.cs
+++ b/tests/coretests/Portfolio/PendingStockPositionTests.cs
@@ -1,5 +1,6 @@
 using System;
 using core.Portfolio;
+using coretests.testdata;
 using Xunit;
 
 namespace coretests.Portfolio
@@ -15,7 +16,7 @@ namespace coretests.Portfolio
                 price: 10,
                 stopPrice: 5,
                 strategy: "alltimehigh",
-                ticker: "AAPL",
+                ticker: TestDataGenerator.TSLA,
                 userId: Guid.NewGuid());
             
             Assert.Equal("this is a note", pending.State.Notes);
@@ -23,7 +24,7 @@ namespace coretests.Portfolio
             Assert.Equal(10, pending.State.Bid);
             Assert.Equal(5, pending.State.StopPrice);
             Assert.Equal("alltimehigh", pending.State.Strategy);
-            Assert.Equal("AAPL", pending.State.Ticker);
+            Assert.Equal(TestDataGenerator.TSLA, pending.State.Ticker);
             Assert.NotEqual(Guid.Empty, pending.State.UserId);
         }
 
@@ -36,7 +37,7 @@ namespace coretests.Portfolio
                 price: 0,
                 stopPrice: 5,
                 strategy: "alltimehigh",
-                ticker: "AAPL",
+                ticker: TestDataGenerator.TSLA,
                 userId: Guid.NewGuid()));
         }
 
@@ -49,7 +50,7 @@ namespace coretests.Portfolio
                 price: 10,
                 stopPrice: 5,
                 strategy: "alltimehigh",
-                ticker: "AAPL",
+                ticker: TestDataGenerator.TSLA,
                 userId: Guid.NewGuid()));
         }
 
@@ -62,7 +63,7 @@ namespace coretests.Portfolio
                 price: 10,
                 stopPrice: -1,
                 strategy: "alltimehigh",
-                ticker: "AAPL",
+                ticker: TestDataGenerator.TSLA,
                 userId: Guid.NewGuid()));
         }
 
@@ -75,7 +76,7 @@ namespace coretests.Portfolio
                 price: 10,
                 stopPrice: 5,
                 strategy: "alltimehigh",
-                ticker: "AAPL",
+                ticker: TestDataGenerator.TSLA,
                 userId: Guid.NewGuid()));
         }
 
@@ -88,23 +89,10 @@ namespace coretests.Portfolio
                 price: 10,
                 stopPrice: 5,
                 strategy: "alltimehigh",
-                ticker: "AAPL",
+                ticker: TestDataGenerator.TSLA,
                 userId: Guid.Empty));
         }
-
-        [Fact]
-        public void Create_WithInvalidTicker_Throws()
-        {
-            Assert.Throws<ArgumentException>(() => new PendingStockPosition(
-                notes: "this is a note",
-                numberOfShares: 100,
-                price: 10,
-                stopPrice: 5,
-                strategy: "alltimehigh",
-                ticker: "",
-                userId: Guid.NewGuid()));
-        }
-
+        
         [Fact]
         public void Create_WithInvalidStrategy_Throws()
         {
@@ -114,7 +102,7 @@ namespace coretests.Portfolio
                 price: 10,
                 stopPrice: 5,
                 strategy: "",
-                ticker: "AAPL",
+                ticker: TestDataGenerator.TSLA,
                 userId: Guid.NewGuid()));
         }
 
@@ -127,7 +115,7 @@ namespace coretests.Portfolio
                 price: 10,
                 stopPrice: 5,
                 strategy: "alltimehigh",
-                ticker: "AAPL",
+                ticker: TestDataGenerator.TSLA,
                 userId: Guid.NewGuid());
 
             pending.Close();

--- a/tests/coretests/Portfolio/StockListTests.cs
+++ b/tests/coretests/Portfolio/StockListTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using core.Portfolio;
+using coretests.testdata;
 using Xunit;
 
 namespace coretests.Portfolio
@@ -58,10 +59,10 @@ namespace coretests.Portfolio
         {
             var list = Create("name", "description");
 
-            list.AddStock("aapl", "note");
+            list.AddStock(TestDataGenerator.TSLA, "note");
 
             Assert.Single(list.State.Tickers);
-            Assert.Equal(new core.Shared.Ticker("aapl"), list.State.Tickers[0].Ticker);
+            Assert.Equal(TestDataGenerator.TSLA, list.State.Tickers[0].Ticker);
         }
 
         [Fact]
@@ -69,10 +70,10 @@ namespace coretests.Portfolio
         {
             var list = Create("name", "description");
 
-            list.AddStock("aapl", null);
+            list.AddStock(TestDataGenerator.TSLA, null);
 
             Assert.Single(list.State.Tickers);
-            Assert.Equal(new core.Shared.Ticker("aapl"), list.State.Tickers[0].Ticker);
+            Assert.Equal(TestDataGenerator.TSLA, list.State.Tickers[0].Ticker);
         }
 
         [Fact]
@@ -80,11 +81,11 @@ namespace coretests.Portfolio
         {
             var list = Create("name", "description");
 
-            list.AddStock("aapl", "note");
+            list.AddStock(TestDataGenerator.TSLA, "note");
 
             Assert.Single(list.State.Tickers);
 
-            list.RemoveStock("aapl");
+            list.RemoveStock(TestDataGenerator.TSLA);
 
             Assert.Empty(list.State.Tickers);
         }
@@ -94,7 +95,7 @@ namespace coretests.Portfolio
         {
             var list = Create("name", "description");
 
-            Assert.Throws<InvalidOperationException>(() => list.RemoveStock("aapl"));
+            Assert.Throws<InvalidOperationException>(() => list.RemoveStock(TestDataGenerator.TSLA));
         }
 
         [Fact]
@@ -102,12 +103,12 @@ namespace coretests.Portfolio
         {
             var list = Create("name", "description");
 
-            list.AddStock("aapl", "note");
+            list.AddStock(TestDataGenerator.TSLA, "note");
 
             var events = list.Events.Count();
 
-            list.AddStock("aapl", "note");
-            list.AddStock("aapl", "note");
+            list.AddStock(TestDataGenerator.TSLA, "note");
+            list.AddStock(TestDataGenerator.TSLA, "note");
 
 
             Assert.Single(list.State.Tickers);

--- a/tests/coretests/Shared/TickerTests.cs
+++ b/tests/coretests/Shared/TickerTests.cs
@@ -7,21 +7,11 @@ namespace coretests.Shared
     public class TickerTests
     {
         [Fact]
-        public void ImplicitConversions()
-        {
-            string val = "tlsa";
-
-            Ticker t = val;
-
-            Assert.Equal("TLSA", t);
-        }
-
-        [Fact]
         public void NullHandling()
         {
             string val = null;
 
-            Assert.Throws<ArgumentException>( () => {Ticker? t = val; });
+            Assert.Throws<ArgumentException>( () => new Ticker(val));
         }
     }
 }

--- a/tests/coretests/Stocks/OwnedStockTests.cs
+++ b/tests/coretests/Stocks/OwnedStockTests.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Linq;
+using core.Shared;
 using core.Stocks;
+using coretests.testdata;
 using Xunit;
 
 namespace coretests.Stocks
@@ -8,15 +10,16 @@ namespace coretests.Stocks
     public class OwnedStockTests
     {
         private static Guid _userId = Guid.NewGuid();
+        private static Ticker TEUM = new Ticker("TEUM");
             
         [Fact]
         public void PurchaseWorks()
         {
-            var stock = new OwnedStock("TEUM", _userId);
+            var stock = new OwnedStock(TEUM, _userId);
 
             stock.Purchase(10, 2.1m, DateTime.UtcNow);
 
-            Assert.Equal("TEUM", stock.State.Ticker);
+            Assert.Equal(TEUM, stock.State.Ticker);
             Assert.Equal(_userId, stock.State.UserId);
             Assert.Equal(10, stock.State.OpenPosition.NumberOfShares);
             Assert.Equal(21, stock.State.OpenPosition.Cost);
@@ -34,7 +37,7 @@ namespace coretests.Stocks
         [Fact]
         public void SellingNotOwnedFails()
         {
-            var stock = new OwnedStock("TEUM", _userId);
+            var stock = new OwnedStock(TEUM, _userId);
 
             stock.Purchase(10, 2.1m, DateTime.UtcNow);
 
@@ -44,7 +47,7 @@ namespace coretests.Stocks
         [Fact]
         public void BuyingForZeroThrows()
         {
-            var stock = new OwnedStock("tlsa", _userId);
+            var stock = new OwnedStock(TestDataGenerator.TSLA, _userId);
 
             Assert.Throws<InvalidOperationException>(() => stock.Purchase(10, 0, DateTime.UtcNow));
         }
@@ -52,7 +55,7 @@ namespace coretests.Stocks
         [Fact]
         public void BuyingWithBadDateThrows()
         {
-            var stock = new OwnedStock("tlsa", _userId);
+            var stock = new OwnedStock(TestDataGenerator.TSLA, _userId);
 
             Assert.Throws<InvalidOperationException>(() => stock.Purchase(10, 0, DateTime.MinValue));
         }
@@ -60,13 +63,13 @@ namespace coretests.Stocks
         [Fact]
         public void BuyingWithBadUserThrows()
         {
-            Assert.Throws<InvalidOperationException>(() => new OwnedStock("tlsa", Guid.Empty));
+            Assert.Throws<InvalidOperationException>(() => new OwnedStock(TestDataGenerator.TSLA, Guid.Empty));
         }
 
         [Fact]
         public void PurchaseWithDateNotProvidedThrows()
         {
-            var stock = new OwnedStock("tlsa", _userId);
+            var stock = new OwnedStock(TestDataGenerator.TSLA, _userId);
 
             Assert.Throws<InvalidOperationException>(() => stock.Purchase(1, 20, DateTime.MinValue));
         }
@@ -74,7 +77,7 @@ namespace coretests.Stocks
         [Fact]
         public void EventCstrReplaysEvents()
         {
-            var stock = new OwnedStock("tlsa", _userId);
+            var stock = new OwnedStock(TestDataGenerator.TSLA, _userId);
 
             stock.Purchase(1, 10, DateTime.UtcNow);
 
@@ -88,7 +91,7 @@ namespace coretests.Stocks
         [Fact]
         public void MultipleBuysAverageCostCorrect()
         {
-            var stock = new OwnedStock("tsla", _userId);
+            var stock = new OwnedStock(TestDataGenerator.TSLA, _userId);
 
             stock.Purchase(1, 5, DateTimeOffset.UtcNow);
             stock.Purchase(1, 10, DateTimeOffset.UtcNow);
@@ -120,7 +123,7 @@ namespace coretests.Stocks
         [Fact]
         public void SellCreatesPLTransaction()
         {
-            var stock = new OwnedStock("tsla", _userId);
+            var stock = new OwnedStock(TestDataGenerator.TSLA, _userId);
 
             // buying two shares one at a time, average cost should be 7.5
             stock.Purchase(1, 5, DateTimeOffset.UtcNow);
@@ -155,7 +158,7 @@ namespace coretests.Stocks
         [Fact]
         public void MultipleBuysDeletingTransactions()
         {
-            var stock = new OwnedStock("tsla", _userId);
+            var stock = new OwnedStock(TestDataGenerator.TSLA, _userId);
 
             stock.Purchase(1, 5, DateTimeOffset.UtcNow);
             stock.Purchase(1, 10, DateTimeOffset.UtcNow);
@@ -187,7 +190,7 @@ namespace coretests.Stocks
         [Fact]
         public void DaysHeldCorrect()
         {
-            var stock = new OwnedStock("tsla", _userId);
+            var stock = new OwnedStock(TestDataGenerator.TSLA, _userId);
 
             stock.Purchase(1, 5, DateTimeOffset.UtcNow.AddDays(-5));
             stock.Purchase(1, 10, DateTimeOffset.UtcNow.AddDays(-2));
@@ -208,7 +211,7 @@ namespace coretests.Stocks
         [Fact]
         public void PositionId_LogicIsCorrect()
         {
-            var stock = new OwnedStock("tsla", _userId);
+            var stock = new OwnedStock(TestDataGenerator.TSLA, _userId);
 
             // first time buying, position should be 0
             // then, once closed out, open position is null
@@ -241,7 +244,7 @@ namespace coretests.Stocks
         [Fact]
         public void AssignGrade_To_OpenPosition_Fails()
         {
-            var stock = new OwnedStock("tsla", _userId);
+            var stock = new OwnedStock(TestDataGenerator.TSLA, _userId);
 
             stock.Purchase(1, 5, DateTimeOffset.UtcNow.AddDays(-5));
 
@@ -253,7 +256,7 @@ namespace coretests.Stocks
         [Fact]
         public void AssignGrade_To_ClosedPosition_Succeeds()
         {
-            var stock = new OwnedStock("tsla", _userId);
+            var stock = new OwnedStock(TestDataGenerator.TSLA, _userId);
 
             stock.Purchase(1, 5, DateTimeOffset.UtcNow.AddDays(-5));
             stock.Sell(1, 6, DateTimeOffset.UtcNow, null);
@@ -271,7 +274,7 @@ namespace coretests.Stocks
         [Fact]
         public void AssignGrade_To_ClosedPosition_UpdatesExistingGrade()
         {
-            var stock = new OwnedStock("tsla", _userId);
+            var stock = new OwnedStock(TestDataGenerator.TSLA, _userId);
 
             stock.Purchase(1, 5, DateTimeOffset.UtcNow.AddDays(-5));
             stock.Sell(1, 6, DateTimeOffset.UtcNow, null);
@@ -288,7 +291,7 @@ namespace coretests.Stocks
         [Fact]
         public void AssignGrade_WithUpdatedNote_RemovesPreviousNoteAndAddsNewOne()
         {
-            var stock = new OwnedStock("tsla", _userId);
+            var stock = new OwnedStock(TestDataGenerator.TSLA, _userId);
 
             stock.Purchase(1, 5, DateTimeOffset.UtcNow.AddDays(-5));
             stock.Sell(1, 6, DateTimeOffset.UtcNow, null);
@@ -307,7 +310,7 @@ namespace coretests.Stocks
         [Fact]
         public void AssignInvalidGrade_Fails()
         {
-            var stock = new OwnedStock("tsla", _userId);
+            var stock = new OwnedStock(TestDataGenerator.TSLA, _userId);
 
             stock.Purchase(1, 5, DateTimeOffset.UtcNow.AddDays(-5));
             stock.Sell(1, 6, DateTimeOffset.UtcNow, null);
@@ -320,7 +323,7 @@ namespace coretests.Stocks
         [Fact]
         public void AssigningStop_Works()
         {
-            var stock = new OwnedStock("tsla", _userId);
+            var stock = new OwnedStock(TestDataGenerator.TSLA, _userId);
 
             stock.Purchase(1, 5, DateTimeOffset.UtcNow.AddDays(-5));
 
@@ -339,7 +342,7 @@ namespace coretests.Stocks
         [Fact]
         public void AssigningStop_ToClosedPosition_Fails()
         {
-            var stock = new OwnedStock("tsla", _userId);
+            var stock = new OwnedStock(TestDataGenerator.TSLA, _userId);
 
             stock.Purchase(1, 5, DateTimeOffset.UtcNow.AddDays(-5));
             stock.Sell(1, 6, DateTimeOffset.UtcNow, null);
@@ -352,7 +355,7 @@ namespace coretests.Stocks
         [Fact]
         public void AddingNote_Works()
         {
-            var stock = new OwnedStock("tsla", _userId);
+            var stock = new OwnedStock(TestDataGenerator.TSLA, _userId);
 
             stock.Purchase(1, 5, DateTimeOffset.UtcNow.AddDays(-5));
 
@@ -371,7 +374,7 @@ namespace coretests.Stocks
         [Fact]
         public void AddingNote_ToClosedPosition_Fails()
         {
-            var stock = new OwnedStock("tsla", _userId);
+            var stock = new OwnedStock(TestDataGenerator.TSLA, _userId);
 
             stock.Purchase(1, 5, DateTimeOffset.UtcNow.AddDays(-5));
             stock.Sell(1, 6, DateTimeOffset.UtcNow, null);
@@ -384,7 +387,7 @@ namespace coretests.Stocks
         [Fact]
         public void DeletePosition_OnClosedPosition_Fails()
         {
-            var stock = new OwnedStock("tsla", _userId);
+            var stock = new OwnedStock(TestDataGenerator.TSLA, _userId);
 
             stock.Purchase(1, 5, DateTimeOffset.UtcNow.AddDays(-5));
             var positionId = stock.State.OpenPosition.PositionId;
@@ -398,7 +401,7 @@ namespace coretests.Stocks
         [Fact]
         public void DeletePosition_Works()
         {
-            var stock = new OwnedStock("tsla", _userId);
+            var stock = new OwnedStock(TestDataGenerator.TSLA, _userId);
 
             stock.Purchase(1, 5, DateTimeOffset.UtcNow.AddDays(-5));
             var positionId = stock.State.OpenPosition.PositionId;
@@ -426,7 +429,7 @@ namespace coretests.Stocks
         [Fact]
         public void LabelsWork()
         {
-            var stock = new OwnedStock("tsla", _userId);
+            var stock = new OwnedStock(TestDataGenerator.TSLA, _userId);
 
             stock.Purchase(1, 5, DateTimeOffset.UtcNow.AddDays(-5));
             var positionId = stock.State.OpenPosition.PositionId;
@@ -444,7 +447,7 @@ namespace coretests.Stocks
         [Fact]
         public void SetLabel_WithNullValue_Fails()
         {
-            var stock = new OwnedStock("tsla", _userId);
+            var stock = new OwnedStock(TestDataGenerator.TSLA, _userId);
 
             stock.Purchase(1, 5, DateTimeOffset.UtcNow.AddDays(-5));
             var positionId = stock.State.OpenPosition.PositionId;
@@ -457,7 +460,7 @@ namespace coretests.Stocks
         [Fact]
         public void SetLabel_WithNullKey_Fails()
         {
-            var stock = new OwnedStock("tsla", _userId);
+            var stock = new OwnedStock(TestDataGenerator.TSLA, _userId);
 
             stock.Purchase(1, 5, DateTimeOffset.UtcNow.AddDays(-5));
             var positionId = stock.State.OpenPosition.PositionId;
@@ -470,7 +473,7 @@ namespace coretests.Stocks
         [Fact]
         public void DeleteLabel_Works()
         {
-            var stock = new OwnedStock("tsla", _userId);
+            var stock = new OwnedStock(TestDataGenerator.TSLA, _userId);
 
             stock.Purchase(1, 5, DateTimeOffset.UtcNow.AddDays(-5));
             var positionId = stock.State.OpenPosition.PositionId;
@@ -488,7 +491,7 @@ namespace coretests.Stocks
         [Fact]
         public void DeleteLabel_WithNullKey_Fails()
         {
-            var stock = new OwnedStock("tsla", _userId);
+            var stock = new OwnedStock(TestDataGenerator.TSLA, _userId);
 
             stock.Purchase(1, 5, DateTimeOffset.UtcNow.AddDays(-5));
             var positionId = stock.State.OpenPosition.PositionId;

--- a/tests/coretests/Stocks/PositionInstanceTests.cs
+++ b/tests/coretests/Stocks/PositionInstanceTests.cs
@@ -1,6 +1,7 @@
 using System;
 using core.Shared;
 using core.Stocks;
+using coretests.testdata;
 using Xunit;
 
 namespace coretests.Stocks
@@ -11,7 +12,7 @@ namespace coretests.Stocks
 
         public PositionInstanceTests()
         {
-            _position = new PositionInstance(0, new Ticker("TSLA"), DateTime.Parse("2020-01-23"));
+            _position = new PositionInstance(0, TestDataGenerator.TSLA, DateTime.Parse("2020-01-23"));
 
             _position.Buy(numberOfShares: 10, price: 30, when: DateTime.Parse("2020-01-23"), transactionId: Guid.NewGuid());
             _position.Buy(numberOfShares: 10, price: 35, when: DateTime.Parse("2020-01-25"), transactionId: Guid.NewGuid());
@@ -66,7 +67,7 @@ namespace coretests.Stocks
         [Fact]
         public void Cost()
         {
-            var position = new PositionInstance(0, "TSLA", DateTime.Parse("2020-01-23"));
+            var position = new PositionInstance(0, TestDataGenerator.TSLA, DateTime.Parse("2020-01-23"));
 
             position.Buy(numberOfShares: 10, price: 30, when: DateTime.Parse("2020-01-23"), transactionId: Guid.NewGuid());
             position.Buy(numberOfShares: 10, price: 35, when: DateTime.Parse("2020-01-25"), transactionId: Guid.NewGuid());
@@ -77,7 +78,7 @@ namespace coretests.Stocks
         [Fact]
         public void SetPrice_SetsVariousMetricsThatDependOnIt()
         {
-            var position = new PositionInstance(0, "TSLA", DateTime.Parse("2020-01-23"));
+            var position = new PositionInstance(0, TestDataGenerator.TSLA, DateTime.Parse("2020-01-23"));
 
             position.Buy(numberOfShares: 10, price: 30, when: DateTime.Parse("2020-01-23"), transactionId: Guid.NewGuid());
             position.Buy(numberOfShares: 10, price: 35, when: DateTime.Parse("2020-01-25"), transactionId: Guid.NewGuid());
@@ -103,7 +104,7 @@ namespace coretests.Stocks
         [Fact]
         public void PercentToStop_WithPriceButNoStop_SetToMax()
         {
-            var position = new PositionInstance(0, "TSLA", DateTime.Parse("2020-01-23"));
+            var position = new PositionInstance(0, TestDataGenerator.TSLA, DateTime.Parse("2020-01-23"));
 
             position.Buy(numberOfShares: 10, price: 30, when: DateTime.Parse("2020-01-23"), transactionId: Guid.NewGuid());
 
@@ -115,7 +116,7 @@ namespace coretests.Stocks
         [Fact]
         public void SetStop_SetsFirstStop()
         {
-            var position = new PositionInstance(0, "TSLA", DateTime.Parse("2020-01-23"));
+            var position = new PositionInstance(0, TestDataGenerator.TSLA, DateTime.Parse("2020-01-23"));
 
             position.Buy(numberOfShares: 10, price: 30, when: DateTime.Parse("2020-01-23"), transactionId: Guid.NewGuid());
             position.SetStopPrice(28, DateTimeOffset.UtcNow);
@@ -130,6 +131,6 @@ namespace coretests.Stocks
         public void IsClosed() => Assert.True(_position.IsClosed);
 
         [Fact]
-        public void Ticker() => Assert.Equal("TSLA", _position.Ticker);
+        public void Ticker() => Assert.Equal(TestDataGenerator.TSLA, _position.Ticker);
     }
 }

--- a/tests/coretests/Stocks/PositionInstanceWithExplicitStopPriceTests.cs
+++ b/tests/coretests/Stocks/PositionInstanceWithExplicitStopPriceTests.cs
@@ -1,5 +1,6 @@
 using System;
 using core.Stocks;
+using coretests.testdata;
 using Xunit;
 
 namespace coretests.Stocks
@@ -10,7 +11,7 @@ namespace coretests.Stocks
 
         public PositionInstanceWithExplicitStopPriceTests()
         {
-            _position = new PositionInstance(0, "TSLA", DateTime.Parse("2020-01-23"));
+            _position = new PositionInstance(0, TestDataGenerator.TSLA, DateTime.Parse("2020-01-23"));
 
             _position.Buy(numberOfShares: 10, price: 30, when: DateTime.Parse("2020-01-23"), transactionId: Guid.NewGuid());
             _position.Buy(numberOfShares: 10, price: 35, when: DateTime.Parse("2020-01-25"), transactionId: Guid.NewGuid());
@@ -29,7 +30,7 @@ namespace coretests.Stocks
         [Fact]
         public void CostAtRiskedBasedOnStopPrice()
         {
-            var position = new PositionInstance(0, "TSLA", DateTime.Parse("2020-01-23"));
+            var position = new PositionInstance(0, TestDataGenerator.TSLA, DateTime.Parse("2020-01-23"));
 
             position.Buy(numberOfShares: 10, price: 30, when: DateTime.Parse("2020-01-23"), transactionId: Guid.NewGuid());
             position.Buy(numberOfShares: 10, price: 35, when: DateTime.Parse("2020-01-25"), transactionId: Guid.NewGuid());

--- a/tests/coretests/Stocks/Services/PositionAnalysisTests.cs
+++ b/tests/coretests/Stocks/Services/PositionAnalysisTests.cs
@@ -15,15 +15,16 @@ namespace coretests.Stocks.Services
     {
         private static (PositionInstance position, PriceBar[] bars, Order[] orders) CreateTestData()
         {
-            var position = new PositionInstance(0, TestDataGenerator.TSLA, System.DateTimeOffset.UtcNow);
+            var ticker = new Ticker("SHEL");
+            var position = new PositionInstance(0, ticker, System.DateTimeOffset.UtcNow);
             position.Buy(numberOfShares: 10, price: 100m, when: System.DateTimeOffset.UtcNow, transactionId: System.Guid.NewGuid());
             position.SetPrice(110m);
             
-            var bars = TestDataGenerator.PriceBars(TestDataGenerator.TSLA.Value);
+            var bars = TestDataGenerator.PriceBars(ticker.Value);
 
             var orders = new[] {
                 new Order {
-                    Ticker = new FSharpOption<Ticker>(TestDataGenerator.TSLA),
+                    Ticker = new FSharpOption<Ticker>(ticker),
                     Price = 100m,
                     Type = "SELL"
                 }

--- a/tests/coretests/Stocks/Services/PositionAnalysisTests.cs
+++ b/tests/coretests/Stocks/Services/PositionAnalysisTests.cs
@@ -15,15 +15,15 @@ namespace coretests.Stocks.Services
     {
         private static (PositionInstance position, PriceBar[] bars, Order[] orders) CreateTestData()
         {
-            var position = new PositionInstance(0, "SHEL", System.DateTimeOffset.UtcNow);
+            var position = new PositionInstance(0, TestDataGenerator.TSLA, System.DateTimeOffset.UtcNow);
             position.Buy(numberOfShares: 10, price: 100m, when: System.DateTimeOffset.UtcNow, transactionId: System.Guid.NewGuid());
             position.SetPrice(110m);
             
-            var bars = TestDataGenerator.PriceBars("SHEL");
+            var bars = TestDataGenerator.PriceBars(TestDataGenerator.TSLA.Value);
 
             var orders = new[] {
                 new Order {
-                    Ticker = new FSharpOption<Ticker>(new Ticker("SHEL")),
+                    Ticker = new FSharpOption<Ticker>(TestDataGenerator.TSLA),
                     Price = 100m,
                     Type = "SELL"
                 }

--- a/tests/coretests/Stocks/Services/Trading/ProfitPointsTests.cs
+++ b/tests/coretests/Stocks/Services/Trading/ProfitPointsTests.cs
@@ -1,6 +1,7 @@
 using System;
 using core.fs.Services.Trading;
 using core.Stocks;
+using coretests.testdata;
 using Xunit;
 
 namespace coretests.Stocks.Services.Trading
@@ -11,7 +12,7 @@ namespace coretests.Stocks.Services.Trading
 
         public ProfitPointsTests()
         {
-            _position = new PositionInstance(0, "TSLA", DateTime.Parse("2020-01-23"));
+            _position = new PositionInstance(0, TestDataGenerator.TSLA, DateTime.Parse("2020-01-23"));
             _position.Buy(numberOfShares: 10, price: 30, when: DateTime.Parse("2020-01-23"), transactionId: Guid.NewGuid());
             _position.Buy(numberOfShares: 10, price: 35, when: DateTime.Parse("2020-01-25"), transactionId: Guid.NewGuid());
 

--- a/tests/coretests/Stocks/Services/Trading/TradingStrategyRunnerTests.cs
+++ b/tests/coretests/Stocks/Services/Trading/TradingStrategyRunnerTests.cs
@@ -9,6 +9,7 @@ using core.fs.Shared.Adapters.Brokerage;
 using core.fs.Shared.Adapters.Stocks;
 using core.Shared;
 using core.Stocks;
+using coretests.testdata;
 using Moq;
 using Xunit;
 
@@ -63,7 +64,7 @@ namespace coretests.Stocks.Services.Trading
                 100,
                 10,
                 5,
-                new Ticker("tsla"),
+                TestDataGenerator.TSLA,
                 DateTimeOffset.UtcNow,
                 false);
 
@@ -102,7 +103,7 @@ namespace coretests.Stocks.Services.Trading
         {
             var bars = GeneratePriceBars(100, i => 10 + i);
 
-            var testPosition = new PositionInstance(0, "tsla", DateTimeOffset.UtcNow);
+            var testPosition = new PositionInstance(0, TestDataGenerator.TSLA, DateTimeOffset.UtcNow);
             testPosition.Buy(2, 10, System.DateTimeOffset.UtcNow, Guid.NewGuid());
             testPosition.SetStopPrice(5, System.DateTimeOffset.UtcNow);
             
@@ -135,7 +136,7 @@ namespace coretests.Stocks.Services.Trading
                 numberOfShares: 2,
                 price: 50,
                 stopPrice: 0.01m,
-                ticker: "tsla",
+                ticker: TestDataGenerator.TSLA,
                 DateTimeOffset.UtcNow,
                 false);
 
@@ -226,7 +227,7 @@ namespace coretests.Stocks.Services.Trading
         {
             var data = GeneratePriceBars(10, i => 50 + i);
 
-            var positionInstance = new PositionInstance(0, "tsla", DateTimeOffset.UtcNow);
+            var positionInstance = new PositionInstance(0, TestDataGenerator.TSLA, DateTimeOffset.UtcNow);
             positionInstance.Buy(
                 numberOfShares: 5,
                 price: 50,
@@ -261,7 +262,7 @@ namespace coretests.Stocks.Services.Trading
         {
             var bars = GeneratePriceBars(20, i => 50 - i);
 
-            var position = new PositionInstance(0, "tsla", DateTimeOffset.UtcNow);
+            var position = new PositionInstance(0, TestDataGenerator.TSLA, DateTimeOffset.UtcNow);
             position.Buy(
                 numberOfShares: 5,
                 price: 50,
@@ -296,7 +297,7 @@ namespace coretests.Stocks.Services.Trading
         {
             var bars = GeneratePriceBars(50, i => 50 + i);
 
-            var position = new PositionInstance(0, "tsla", DateTimeOffset.UtcNow);
+            var position = new PositionInstance(0, TestDataGenerator.TSLA, DateTimeOffset.UtcNow);
             position.Buy(
                 numberOfShares: 5,
                 price: 50,
@@ -334,7 +335,7 @@ namespace coretests.Stocks.Services.Trading
         {
             var bars = GeneratePriceBars(10, i => 50 - i);
 
-            var positionInstance = new PositionInstance(0, "tsla", DateTimeOffset.UtcNow);
+            var positionInstance = new PositionInstance(0, TestDataGenerator.TSLA, DateTimeOffset.UtcNow);
             positionInstance.Buy(
                 numberOfShares: 5,
                 price: 50,

--- a/tests/coretests/Stocks/TradingDataGenerator.cs
+++ b/tests/coretests/Stocks/TradingDataGenerator.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using core.Shared;
 using core.Stocks;
+using coretests.testdata;
 
 namespace coretests.Stocks
 {
@@ -10,17 +12,17 @@ namespace coretests.Stocks
         {
             var closedPositions = new List<PositionInstance>();
 
-            var position = new PositionInstance(0, "AMD", DateTimeOffset.Now.AddDays(-1));
+            var position = new PositionInstance(0, TestDataGenerator.TSLA, DateTimeOffset.Now.AddDays(-1));
             position.Buy(1, 100m, DateTimeOffset.Now.AddDays(-1), transactionId: Guid.NewGuid());
             position.Sell(1, 110m, transactionId: Guid.NewGuid(), DateTimeOffset.Now);
             closedPositions.Add(position);
 
-            position = new PositionInstance(1, "AMD", DateTimeOffset.Now.AddDays(-1));
+            position = new PositionInstance(1, TestDataGenerator.TSLA, DateTimeOffset.Now.AddDays(-1));
             position.Buy(1, 100m, DateTimeOffset.Now.AddDays(-1), transactionId: Guid.NewGuid());
             position.Sell(1, 110m, transactionId: Guid.NewGuid(), DateTimeOffset.Now);
             closedPositions.Add(position);
 
-            position = new PositionInstance(2, "AMD", DateTimeOffset.Now.AddDays(-1));
+            position = new PositionInstance(2, TestDataGenerator.TSLA, DateTimeOffset.Now.AddDays(-1));
             position.Buy(1, 100m, DateTimeOffset.Now.AddDays(-1), transactionId: Guid.NewGuid());
             position.Sell(1, 90m, transactionId: Guid.NewGuid(), DateTimeOffset.Now);
             closedPositions.Add(position);
@@ -56,7 +58,7 @@ namespace coretests.Stocks
         }
         
         private const string Chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-        private static string GenerateRandomTicker(Random random)
+        private static Ticker GenerateRandomTicker(Random random)
         {
             var length = random.Next(3, 5);
             var ticker = new char[length];
@@ -64,7 +66,7 @@ namespace coretests.Stocks
             {
                 ticker[i] = Chars[random.Next(Chars.Length)];
             }
-            return ticker.ToString();
+            return new Ticker(ticker.ToString());
         }
     }
 }

--- a/tests/coretests/testdata/TestDataGenerator.cs
+++ b/tests/coretests/testdata/TestDataGenerator.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Linq;
 using core.fs.Shared.Adapters.Stocks;
+using core.Shared;
 
 namespace coretests.testdata
 {
@@ -36,5 +37,6 @@ namespace coretests.testdata
         }
         
         public static string RandomEmail() => $"{Guid.NewGuid().ToString()}@gmail.com";
+        public static Ticker TSLA = new("tsla");
     }
 }

--- a/tests/infrastructuretests/csvparsertests/CSVExportTests.cs
+++ b/tests/infrastructuretests/csvparsertests/CSVExportTests.cs
@@ -6,6 +6,7 @@ using core.Notes;
 using core.Options;
 using core.Shared;
 using core.Stocks;
+using coretests.testdata;
 using csvparser;
 using Xunit;
 
@@ -17,13 +18,13 @@ namespace csvparsertests
         [Fact]
         public void ExportStocksHeader()
         {
-            var stock = new OwnedStock(new Ticker("tsla"), Guid.NewGuid());
+            var stock = new OwnedStock(TestDataGenerator.TSLA, Guid.NewGuid());
             stock.Purchase(1, 100, DateTime.UtcNow, "some note");
             
             var report = CSVExport.stocks(_csvWriter, new[] {stock});
 
             Assert.Contains("Ticker,Type,Amount,Price,Date,Notes", report);
-            Assert.Contains("TSLA", report);
+            Assert.Contains(TestDataGenerator.TSLA.Value, report);
         }
 
         [Fact]
@@ -46,7 +47,7 @@ namespace csvparsertests
         public void ExportOptionsHeader()
         {
             var option = new OwnedOption(
-                "tlsa",
+                new Ticker("tlsa"),
                 2.5m,
                 OptionType.CALL,
                 DateTimeOffset.UtcNow.AddDays(1),
@@ -66,12 +67,12 @@ namespace csvparsertests
         [Fact]
         public void ExportNotes()
         {
-            var note = new Note(Guid.NewGuid(), "my note", "stockticker", DateTimeOffset.UtcNow);
+            var note = new Note(Guid.NewGuid(), "my note", TestDataGenerator.TSLA, DateTimeOffset.UtcNow);
 
             var report = CSVExport.notes(_csvWriter, new[] {note});
 
             Assert.Contains("Created,Ticker,Note", report);
-            Assert.Contains(note.State.RelatedToTicker, report);
+            Assert.Contains(note.State.RelatedToTicker.Value, report);
             Assert.Contains("my note", report);
         }
 

--- a/tests/infrastructuretests/csvparsertests/csvparsertests.csproj
+++ b/tests/infrastructuretests/csvparsertests/csvparsertests.csproj
@@ -25,6 +25,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\infrastructure\csvparser\csvparser.csproj" />
+    <ProjectReference Include="..\..\coretests\coretests.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/storagetests/storagetests.csproj
+++ b/tests/storagetests/storagetests.csproj
@@ -23,6 +23,7 @@
     <ProjectReference Include="..\..\src\infrastructure\storage.postgres\storage.postgres.csproj" />
 	  <ProjectReference Include="..\..\src\core\core.csproj" />
 	  <ProjectReference Include="..\..\src\infrastructure\storage.memory\storage.memory.csproj" />
+	  <ProjectReference Include="..\coretests\coretests.csproj" />
 	  <ProjectReference Include="..\testutils\testutils.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
It makes it too easy to mix strings and tickers and it's better to stay explicit.