### PR TITLE
SPA setup upgrade

### DIFF
--- a/src/web/ClientApp/angular.json
+++ b/src/web/ClientApp/angular.json
@@ -11,7 +11,7 @@
       "schematics": {},
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:browser",
+          "builder": "@angular-devkit/build-angular:browser-esbuild",
           "options": {
             "progress": true,
             "outputPath": "dist",
@@ -55,9 +55,19 @@
               "extractLicenses": true,
               "vendorChunk": false,
               "buildOptimizer": true
+            },
+            "development": {
+              "optimization": false,
+              "outputHashing": "all",
+              "sourceMap": true,
+              "namedChunks": true,
+              "aot": false,
+              "extractLicenses": false,
+              "vendorChunk": true,
+              "buildOptimizer": false
             }
           },
-          "defaultConfiguration": ""
+          "defaultConfiguration": "production"
         },
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
@@ -72,7 +82,8 @@
               "proxyConfig": "proxy.conf.js",
               "buildTarget": "web:build:development"
             }
-          }
+          },
+          "defaultConfiguration": "development"
         },
         "extract-i18n": {
           "builder": "@angular-devkit/build-angular:extract-i18n",
@@ -119,7 +130,7 @@
               "buildOptimizer": true
             }
           },
-          "defaultConfiguration": ""
+          "defaultConfiguration": "dev"
         }
       }
     },

--- a/src/web/ClientApp/angular.json
+++ b/src/web/ClientApp/angular.json
@@ -67,6 +67,10 @@
           "configurations": {
             "production": {
               "buildTarget": "web:build:production"
+            },
+            "development": {
+              "proxyConfig": "proxy.conf.js",
+              "buildTarget": "web:build:development"
             }
           }
         },

--- a/src/web/ClientApp/aspnetcore-https.js
+++ b/src/web/ClientApp/aspnetcore-https.js
@@ -1,0 +1,33 @@
+// This script sets up HTTPS for the application using the ASP.NET Core HTTPS certificate
+const fs = require('fs');
+const spawn = require('child_process').spawn;
+const path = require('path');
+
+const baseFolder =
+  process.env.APPDATA !== undefined && process.env.APPDATA !== ''
+    ? `${process.env.APPDATA}/ASP.NET/https`
+    : `${process.env.HOME}/.aspnet/https`;
+
+const certificateArg = process.argv.map(arg => arg.match(/--name=(?<value>.+)/i)).filter(Boolean)[0];
+const certificateName = certificateArg ? certificateArg.groups.value : process.env.npm_package_name;
+
+if (!certificateName) {
+  console.error('Invalid certificate name. Run this script in the context of an npm/yarn script or pass --name=<<app>> explicitly.')
+  process.exit(-1);
+}
+
+const certFilePath = path.join(baseFolder, `${certificateName}.pem`);
+const keyFilePath = path.join(baseFolder, `${certificateName}.key`);
+
+if (!fs.existsSync(certFilePath) || !fs.existsSync(keyFilePath)) {
+  spawn('dotnet', [
+    'dev-certs',
+    'https',
+    '--export-path',
+    certFilePath,
+    '--format',
+    'Pem',
+    '--no-password',
+  ], { stdio: 'inherit', })
+    .on('exit', (code) => process.exit(code));
+}

--- a/src/web/ClientApp/package-lock.json
+++ b/src/web/ClientApp/package-lock.json
@@ -58,6 +58,7 @@
         "npm-registry-fetch": ">=4.0.5",
         "object-path": ">=0.11.5",
         "protractor": "^7.0.0",
+        "run-script-os": "^1.1.6",
         "ts-node": "^8.10.2",
         "tslint": "^6.1.3",
         "typescript": "~5.2.2",
@@ -14044,6 +14045,16 @@
       ],
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/run-script-os": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/run-script-os/-/run-script-os-1.1.6.tgz",
+      "integrity": "sha512-ql6P2LzhBTTDfzKts+Qo4H94VUKpxKDFz6QxxwaUZN0mwvi7L3lpOI7BqPCq7lgDh3XLl0dpeXwfcVIitlrYrw==",
+      "dev": true,
+      "bin": {
+        "run-os": "index.js",
+        "run-script-os": "index.js"
       }
     },
     "node_modules/rx": {

--- a/src/web/ClientApp/package.json
+++ b/src/web/ClientApp/package.json
@@ -4,7 +4,9 @@
   "scripts": {
     "ng": "ng",
     "prestart": "node aspnetcore-https",
-    "start": "ng serve --port 44406 --ssl --ssl-cert \"%APPDATA%\\ASP.NET\\https\\%npm_package_name%.pem\" --ssl-key \"%APPDATA%\\ASP.NET\\https\\%npm_package_name%.key\"",
+    "start": "run-script-os",
+    "start:windows": "ng serve --port 44406 --ssl --ssl-cert \"%APPDATA%\\ASP.NET\\https\\%npm_package_name%.pem\" --ssl-key \"%APPDATA%\\ASP.NET\\https\\%npm_package_name%.key\"",
+    "start:default": "ng serve --port 44406 --ssl --ssl-cert \"$HOME/.aspnet/https/${npm_package_name}.pem\" --ssl-key \"$HOME/.aspnet/https/${npm_package_name}.key\"",
     "build": "ng build",
     "build:ssr": "ng run tradewatch:server:dev",
     "watch": "ng build --watch --configuration development",

--- a/src/web/ClientApp/package.json
+++ b/src/web/ClientApp/package.json
@@ -3,12 +3,12 @@
   "version": "2.0.36",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve",
-    "build": "ng build --progress=false",
-    "build:production": "ng build --progress=false --configuration production",
-    "test": "ng test",
-    "lint": "ng lint",
-    "e2e": "ng e2e"
+    "prestart": "node aspnetcore-https",
+    "start": "ng serve --port 44406 --ssl --ssl-cert \"%APPDATA%\\ASP.NET\\https\\%npm_package_name%.pem\" --ssl-key \"%APPDATA%\\ASP.NET\\https\\%npm_package_name%.key\"",
+    "build": "ng build",
+    "build:ssr": "ng run tradewatch:server:dev",
+    "watch": "ng build --watch --configuration development",
+    "test": "ng test"
   },
   "private": true,
   "dependencies": {

--- a/src/web/ClientApp/package.json
+++ b/src/web/ClientApp/package.json
@@ -64,6 +64,7 @@
     "npm-registry-fetch": ">=4.0.5",
     "object-path": ">=0.11.5",
     "protractor": "^7.0.0",
+    "run-script-os": "^1.1.6",
     "ts-node": "^8.10.2",
     "tslint": "^6.1.3",
     "typescript": "~5.2.2",

--- a/src/web/ClientApp/proxy.conf.js
+++ b/src/web/ClientApp/proxy.conf.js
@@ -6,7 +6,9 @@ const target = env.ASPNETCORE_HTTPS_PORT ? `https://localhost:${env.ASPNETCORE_H
 const PROXY_CONFIG = [
   {
     context: [
-      "/weatherforecast",
+      "/api",
+      "/tradingview.png",
+      "/styles.css"
     ],
     target: target,
     secure: false,

--- a/src/web/ClientApp/proxy.conf.js
+++ b/src/web/ClientApp/proxy.conf.js
@@ -1,0 +1,19 @@
+const { env } = require('process');
+
+const target = env.ASPNETCORE_HTTPS_PORT ? `https://localhost:${env.ASPNETCORE_HTTPS_PORT}` :
+  env.ASPNETCORE_URLS ? env.ASPNETCORE_URLS.split(';')[0] : 'http://localhost:49213';
+
+const PROXY_CONFIG = [
+  {
+    context: [
+      "/weatherforecast",
+    ],
+    target: target,
+    secure: false,
+    headers: {
+      Connection: 'Keep-Alive'
+    }
+  }
+]
+
+module.exports = PROXY_CONFIG;

--- a/src/web/Properties/launchSettings.json
+++ b/src/web/Properties/launchSettings.json
@@ -18,7 +18,7 @@
     "web": {
       "commandName": "Project",
       "launchBrowser": true,
-      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "applicationUrl": "https://localhost:5002;http://localhost:5000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development", 
         "ASPNETCORE_HOSTINGSTARTUPASSEMBLIES": "Microsoft.AspNetCore.SpaProxy"

--- a/src/web/Properties/launchSettings.json
+++ b/src/web/Properties/launchSettings.json
@@ -20,7 +20,8 @@
       "launchBrowser": true,
       "applicationUrl": "https://localhost:5001;http://localhost:5000",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Development", 
+        "ASPNETCORE_HOSTINGSTARTUPASSEMBLIES": "Microsoft.AspNetCore.SpaProxy"
       }
     }
   }

--- a/src/web/Startup.cs
+++ b/src/web/Startup.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.HttpOverrides;
-using Microsoft.AspNetCore.SpaServices.AngularCli;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -65,11 +64,11 @@ namespace web
             services.AddHealthChecks()
                 .AddCheck<HealthCheck>("storage based health check");
 
-            // In production, the Angular files will be served from this directory
-            services.AddSpaStaticFiles(configuration =>
-            {
-                configuration.RootPath = "ClientApp/dist";
-            });
+            // // In production, the Angular files will be served from this directory
+            // services.AddSpaStaticFiles(configuration =>
+            // {
+            //     configuration.RootPath = "ClientApp/dist";
+            // });
 
             DIHelper.RegisterServices(Configuration, services, Logger);
         }
@@ -102,7 +101,7 @@ namespace web
             }
 
             app.UseStaticFiles();
-            app.UseSpaStaticFiles();
+            // app.UseSpaStaticFiles();
 
             app.UseRouting();
 
@@ -115,26 +114,26 @@ namespace web
                 endpoints.MapControllerRoute("default", "api/{controller=Home}/{action=Index}/{id?}");
             });
 
-            app.UseSpa(spa =>
-            {
-                spa.Options.SourcePath = "ClientApp";
-                if (env.IsDevelopment())
-                {
-                    spa.UseAngularCliServer(npmScript: "start");
-                }
-
-                spa.Options.DefaultPageStaticFileOptions = new StaticFileOptions
-                {
-                    OnPrepareResponse = context =>
-                    {
-                        if (context.File.Name == "index.html")
-                        {
-                            context.Context.Response.Headers.Add("Cache-Control", "no-cache, no-store");
-                            context.Context.Response.Headers.Add("Expires", "-1");
-                        }
-                    }
-                };
-            });
+            // app.UseSpa(spa =>
+            // {
+            //     spa.Options.SourcePath = "ClientApp";
+            //     if (env.IsDevelopment())
+            //     {
+            //         spa.UseAngularCliServer(npmScript: "start");
+            //     }
+            //
+            //     spa.Options.DefaultPageStaticFileOptions = new StaticFileOptions
+            //     {
+            //         OnPrepareResponse = context =>
+            //         {
+            //             if (context.File.Name == "index.html")
+            //             {
+            //                 context.Context.Response.Headers.Add("Cache-Control", "no-cache, no-store");
+            //                 context.Context.Response.Headers.Add("Expires", "-1");
+            //             }
+            //         }
+            //     };
+            // });
         }
     }
 }

--- a/src/web/web.csproj
+++ b/src/web/web.csproj
@@ -78,6 +78,7 @@
       <ResolvedFileToPublish Include="@(DistFiles->'%(FullPath)')" Exclude="@(ResolvedFileToPublish)">
           <RelativePath>wwwroot\%(RecursiveDir)%(FileName)%(Extension)</RelativePath>
         <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+          <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
       </ResolvedFileToPublish>
     </ItemGroup>
   </Target>

--- a/src/web/web.csproj
+++ b/src/web/web.csproj
@@ -7,13 +7,15 @@
     <IsPackable>false</IsPackable>
     <SpaRoot>ClientApp\</SpaRoot>
     <DefaultItemExcludes>$(DefaultItemExcludes);$(SpaRoot)node_modules\**</DefaultItemExcludes>
-    <BuildServerSideRenderer>false</BuildServerSideRenderer>
-    <LangVersion>Latest</LangVersion>
+      <BuildServerSideRenderer>false</BuildServerSideRenderer>
+      <SpaProxyServerUrl>https://localhost:44406</SpaProxyServerUrl>
+      <SpaProxyLaunchCommand>npm start</SpaProxyLaunchCommand>
+      <LangVersion>Latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="7.0.13" />
-    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="7.0.13" />
+    <PackageReference Include="Microsoft.AspNetCore.SpaProxy" Version="7.0.13" />
   </ItemGroup>
 
   <ItemGroup>
@@ -67,7 +69,7 @@
   <Target Name="PublishRunWebpack" AfterTargets="ComputeFilesToPublish">
     <!-- As part of publishing, ensure the JS resources are freshly built in production mode -->
     <Exec WorkingDirectory="$(SpaRoot)" Command="npm install" />
-    <Exec WorkingDirectory="$(SpaRoot)" Command="npm run build:production" />
+      <Exec WorkingDirectory="$(SpaRoot)" Command="npm run build -- --configuration production" />
 
     <!-- Include the newly-built files in the publish output -->
     <ItemGroup>

--- a/src/web/web.csproj
+++ b/src/web/web.csproj
@@ -76,7 +76,7 @@
       <DistFiles Include="$(SpaRoot)dist\**; $(SpaRoot)dist-server\**" />
       <DistFiles Include="$(SpaRoot)node_modules\**" Condition="'$(BuildServerSideRenderer)' == 'true'" />
       <ResolvedFileToPublish Include="@(DistFiles->'%(FullPath)')" Exclude="@(ResolvedFileToPublish)">
-        <RelativePath>%(DistFiles.Identity)</RelativePath>
+          <RelativePath>wwwroot\%(RecursiveDir)%(FileName)%(Extension)</RelativePath>
         <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
       </ResolvedFileToPublish>
     </ItemGroup>


### PR DESCRIPTION
web.csproj is using SPA setup that's very outdated from what the latest setup looks like with angular templates. The old setup does not work if you try to use Angular 17 new build system, the URL detection is broken. Also new setup no longer requires Use/Add SpaStaticFiles.