### PR TITLE
Short stock position support

### DIFF
--- a/src/core.fs/Shared.fs
+++ b/src/core.fs/Shared.fs
@@ -3,6 +3,7 @@ namespace core.fs
 open System
 open System.Collections.Generic
 
+
 type IApplicationService = interface end
    
    

--- a/src/core.fs/Stocks.fs
+++ b/src/core.fs/Stocks.fs
@@ -340,6 +340,11 @@ module StockPosition =
         StockPositionOpened(Guid.NewGuid(), Guid.NewGuid(), date, ticker.Value, Short)
         |> createInitialState
         
+    let ``open`` (ticker:Ticker) (numberOfShares:decimal) price date =
+        match numberOfShares > 0m with
+        | true -> openLong ticker date |> buy numberOfShares price date
+        | false -> openShort ticker date |> sell (numberOfShares |> abs) price date
+        
     let addNotes = applyNotesIfApplicable
         
     let setLabel key value date stockPosition =
@@ -351,6 +356,11 @@ module StockPosition =
         | _ ->
             let e = StockPositionLabelSet(Guid.NewGuid(), stockPosition.PositionId |> StockPositionId.guid, date, key, value)
             apply e stockPosition
+            
+    let setLabelIfValueNotNone key value date stockPosition =
+        match value with
+        | None -> stockPosition
+        | Some value -> setLabel key value date stockPosition
             
     let deleteLabel key date stockPosition =
         

--- a/src/migrations/Library.fs
+++ b/src/migrations/Library.fs
@@ -11,6 +11,11 @@ open storage.shared
 // we will be migrating from OwnedStockState silliness to StockPosition
 module MigrateFromV2ToV3 =
     
+    let stringToSome s =
+        match s with
+        | null -> None
+        | _ -> Some s
+        
     let mapToStockPositionEvent (t:PositionEvent) =
         match t.Type.Value with
         | PositionEventType.Buy -> fun sp ->

--- a/src/migrations/Library.fs
+++ b/src/migrations/Library.fs
@@ -11,11 +11,6 @@ open storage.shared
 // we will be migrating from OwnedStockState silliness to StockPosition
 module MigrateFromV2ToV3 =
     
-    let stringToSome s =
-        match s with
-        | null -> None
-        | _ -> Some s
-        
     let mapToStockPositionEvent (t:PositionEvent) =
         match t.Type.Value with
         | PositionEventType.Buy -> fun sp ->

--- a/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-new-position.component.html
+++ b/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-new-position.component.html
@@ -68,6 +68,8 @@
         <div class="col-md-3">
           <label for="stocksToBuy" class="form-label">Shares #</label>
           <input
+            min="-10000"
+            max="10000"
             type="number"
             id="stocksToBuy"
             class="form-control"

--- a/src/web/Controllers/PortfolioController.cs
+++ b/src/web/Controllers/PortfolioController.cs
@@ -208,7 +208,7 @@ public class PortfolioController : ControllerBase
         );
     
     [HttpPost("stockpositions")]
-    public Task<ActionResult> OpenLongPosition([FromBody]OpenLongStockPosition command) =>
+    public Task<ActionResult> OpenLongPosition([FromBody]OpenStockPosition command) =>
         this.OkOrError(
             _handler.Handle(
                 User.Identifier(), command

--- a/tests/coretests.fs/Stocks/StockPositionLongTests.fs
+++ b/tests/coretests.fs/Stocks/StockPositionLongTests.fs
@@ -13,9 +13,7 @@ let ticker = TestDataGenerator.TEUM
 [<Fact>]
 let ``Purchase works`` () =
     
-    let stock =
-        StockPosition.openLong ticker DateTimeOffset.UtcNow
-        |> StockPosition.buy 10m 2.1m DateTimeOffset.UtcNow
+    let stock = StockPosition.``open`` ticker 10m 2.1m DateTimeOffset.UtcNow
     
     stock.Ticker |> should equal ticker
     stock.NumberOfShares |> should equal 10

--- a/tests/coretests.fs/Stocks/StockPositionShortTests.fs
+++ b/tests/coretests.fs/Stocks/StockPositionShortTests.fs
@@ -12,9 +12,7 @@ let ticker = TestDataGenerator.TEUM
 [<Fact>]
 let ``Opening short position works`` () =
     
-    let position =
-        StockPosition.openShort ticker DateTimeOffset.UtcNow
-        |> StockPosition.sell 10m 1.5m DateTimeOffset.UtcNow
+    let position = StockPosition.``open`` ticker -10m 1.5m DateTimeOffset.UtcNow
         
     position.NumberOfShares |> should equal -10m
     position.IsShort |> should equal true

--- a/tests/coretests.fs/Stocks/StockPositionShortTests.fs
+++ b/tests/coretests.fs/Stocks/StockPositionShortTests.fs
@@ -1,0 +1,73 @@
+module coretests.fs.Stocks.StockPositionShortTests
+
+open System
+open Xunit
+open FsUnit
+open core.fs.Stocks
+open coretests.testdata
+
+let userId = TestDataGenerator.RandomUserId()
+let ticker = TestDataGenerator.TEUM
+
+[<Fact>]
+let ``Opening short position works`` () =
+    
+    let position =
+        StockPosition.openShort ticker DateTimeOffset.UtcNow
+        |> StockPosition.sell 10m 1.5m DateTimeOffset.UtcNow
+        
+    position.NumberOfShares |> should equal -10m
+    position.IsShort |> should equal true
+    
+[<Fact>]
+let ``Buying shares of short position works`` () =
+    
+    let position =
+        StockPosition.openShort ticker DateTimeOffset.UtcNow
+        |> StockPosition.sell 10m 1.5m DateTimeOffset.UtcNow
+        |> StockPosition.buy 5m 1.5m DateTimeOffset.UtcNow
+        
+    position.NumberOfShares |> should equal -5m
+    position.IsShort |> should equal true
+    position.IsOpen |> should equal true
+    
+[<Fact>]
+let ``Buying all shares of short position works`` () =
+    
+    let position =
+        StockPosition.openShort ticker DateTimeOffset.UtcNow
+        |> StockPosition.sell 10m 1.5m DateTimeOffset.UtcNow
+        |> StockPosition.buy 10m 1.5m DateTimeOffset.UtcNow
+        
+    position.NumberOfShares |> should equal 0m
+    position.IsShort |> should equal true
+    position.IsClosed |> should equal true
+    
+    
+[<Fact>]
+let ``Buying more shares than available in short position throws`` () =
+    
+    let position =
+        StockPosition.openShort ticker DateTimeOffset.UtcNow
+        |> StockPosition.sell 10m 1.5m DateTimeOffset.UtcNow
+        
+    (fun () -> position |> StockPosition.buy 15m 1.5m DateTimeOffset.UtcNow |> ignore)
+    |> should throw typeof<Exception>
+    
+[<Fact>]
+let ``From events recreates identical state`` () =
+    
+    let position =
+        StockPosition.openShort ticker DateTimeOffset.UtcNow
+        |> StockPosition.sell 10m 1.5m DateTimeOffset.UtcNow
+        |> StockPosition.buy 5m 1.5m DateTimeOffset.UtcNow
+        
+    let position2 =
+        position.Events
+        |> StockPosition.createFromEvents
+        
+    position2.NumberOfShares |> should equal position.NumberOfShares
+    position2.IsShort |> should equal position.IsShort
+    position2.IsOpen |> should equal position.IsOpen
+    position2.Ticker |> should equal position.Ticker
+    position2.PositionId |> should equal position.PositionId

--- a/tests/coretests.fs/Stocks/StockPositionWithCalculationsTests.fs
+++ b/tests/coretests.fs/Stocks/StockPositionWithCalculationsTests.fs
@@ -7,8 +7,11 @@ open core.fs.Stocks
 open coretests.testdata
 
 
+let ticker = TestDataGenerator.NET
+
+[<Fact>]
 let position =
-    StockPosition.openLong TestDataGenerator.NET (DateTimeOffset.Parse("2020-01-23"))
+    StockPosition.openLong ticker (DateTimeOffset.Parse("2020-01-23"))
     |> StockPosition.buy 10m 30m (DateTimeOffset.Parse("2020-01-23"))
     |> StockPosition.buy 10m 35m (DateTimeOffset.Parse("2020-01-25"))
     |> StockPosition.sell 10m 40m (DateTimeOffset.Parse("2020-02-25"))
@@ -16,7 +19,7 @@ let position =
     |> StockPositionWithCalculations
     
 let positionWithStop =
-    StockPosition.openLong TestDataGenerator.NET (DateTimeOffset.Parse("2020-01-23"))
+    StockPosition.openLong ticker (DateTimeOffset.Parse("2020-01-23"))
     |> StockPosition.buy 10m 30m (DateTimeOffset.Parse("2020-01-23"))
     |> StockPosition.buy 10m 35m (DateTimeOffset.Parse("2020-01-25"))
     |> StockPosition.setStop (Some 28m) (DateTimeOffset.Parse("2020-01-25"))
@@ -24,7 +27,14 @@ let positionWithStop =
     |> StockPosition.sell 10m 37m (DateTimeOffset.Parse("2020-03-21"))
     |> StockPositionWithCalculations
     
-
+let shortPosition =
+    StockPosition.openShort ticker (DateTimeOffset.Parse("2020-01-23"))
+    |> StockPosition.sell 10m 40m (DateTimeOffset.Parse("2020-01-23"))
+    |> StockPosition.sell 10m 37m (DateTimeOffset.Parse("2020-01-25"))
+    |> StockPosition.buy 10m 35m (DateTimeOffset.Parse("2020-02-25"))
+    |> StockPosition.buy 10m 30m (DateTimeOffset.Parse("2020-03-21"))
+    |> StockPositionWithCalculations
+    
 [<Fact>]
 let ``LastBuyPrice is accurate`` () =
     position.LastBuyPrice |> should equal 35m
@@ -49,7 +59,6 @@ let ``First Buy Cost Accurate`` () =
 let ``Completed position cost per share accurate`` () =
     position.CompletedPositionCostPerShare |> should equal 32.5m
 
-
 [<Fact>]
 let ``Completed position number of shares accurate`` () =
     position.CompletedPositionShares |> should equal 20m
@@ -57,11 +66,54 @@ let ``Completed position number of shares accurate`` () =
 [<Fact>]
 let ``Risked amount is accurate`` () =
     positionWithStop.RiskedAmount.Value |> should equal 90m
+
+// generate the same tests as above but for short position
+[<Fact>]
+let ``Short LastBuyPrice is accurate`` () =
+    shortPosition.LastBuyPrice |> should equal 30m
     
+[<Fact>]
+let ``Short LastSellPrice is accurate`` () =
+    shortPosition.LastSellPrice |> should equal 37m
+    
+[<Fact>]
+let ``Short GainPct is accurate`` () =
+    Assert.Equal(0.18m, shortPosition.GainPct, 2)
+    
+[<Fact>]
+let ``Short First Buy Cost Accurate`` () =
+    shortPosition.FirstBuyPrice |> should equal 35m
+    
+[<Fact>]
+let ``Short Completed position cost per share accurate`` () =
+    shortPosition.CompletedPositionCostPerShare |> should equal 38.5m
+    
+[<Fact>]
+let ``Short Completed position number of shares accurate`` () =
+    shortPosition.CompletedPositionShares |> should equal 20m
+    
+[<Fact>]
+let ``Short Average buy cost per share is accurate``() =
+    shortPosition.AverageBuyCostPerShare |> should equal 32.5m
+    
+[<Fact>]
+let ``Short Days held is accurate`` () =
+    Math.Abs(57 - shortPosition.DaysHeld) |> should be (lessThanOrEqualTo 1)
+    
+[<Fact>]
+let ``Short Cost is accurate`` () =
+    let position =
+        StockPosition.openShort ticker (DateTimeOffset.Parse("2020-01-23"))
+        |> StockPosition.sell 10m 30m (DateTimeOffset.Parse("2020-01-23"))
+        |> StockPosition.sell 10m 35m (DateTimeOffset.Parse("2020-01-25"))
+        |> StockPositionWithCalculations
+        
+    position.Cost |> should equal -650m
+
 [<Fact>]
 let ``Cost at risk based on stop price is accurate`` () =
     let position =
-        StockPosition.openLong TestDataGenerator.NET (DateTimeOffset.Parse("2020-01-23"))
+        StockPosition.openLong ticker (DateTimeOffset.Parse("2020-01-23"))
         |> StockPosition.buy 10m 30m (DateTimeOffset.Parse("2020-01-23"))
         |> StockPosition.buy 10m 35m (DateTimeOffset.Parse("2020-01-25"))
         |> StockPosition.setStop (Some 20m) (DateTimeOffset.Parse("2020-01-25"))
@@ -87,7 +139,7 @@ let ``Days held is accurate`` () =
 [<Fact>]
 let ``Cost is accurate`` () =
     let position =
-        StockPosition.openLong TestDataGenerator.NET (DateTimeOffset.Parse("2020-01-23"))
+        StockPosition.openLong ticker (DateTimeOffset.Parse("2020-01-23"))
         |> StockPosition.buy 10m 30m (DateTimeOffset.Parse("2020-01-23"))
         |> StockPosition.buy 10m 35m (DateTimeOffset.Parse("2020-01-25"))
         |> StockPositionWithCalculations
@@ -97,7 +149,7 @@ let ``Cost is accurate`` () =
 [<Fact>]
 let ``Set stop sets first stop`` () =
     let position =
-        StockPosition.openLong TestDataGenerator.NET (DateTimeOffset.Parse("2020-01-23"))
+        StockPosition.openLong ticker (DateTimeOffset.Parse("2020-01-23"))
         |> StockPosition.buy 10m 30m (DateTimeOffset.Parse("2020-01-23"))
         |> StockPosition.setStop (Some 28m) (DateTimeOffset.Parse("2020-01-25"))
         |> StockPosition.setStop (Some 29m) (DateTimeOffset.Parse("2020-01-25"))
@@ -115,4 +167,76 @@ let ``Position closed date is accurate``() =
     
 [<Fact>]
 let ``Ticker is set``() =
-    position.Ticker |> should equal TestDataGenerator.NET
+    position.Ticker |> should equal ticker
+    
+   
+[<Fact>]
+let ``Multiple buys average cost correct`` () =
+    let purchase1 =
+        StockPosition.openLong ticker DateTimeOffset.UtcNow
+        |> StockPosition.buy 1m 5m DateTimeOffset.UtcNow
+        |> StockPosition.buy 1m 10m DateTimeOffset.UtcNow
+    
+    let withCalculation = purchase1 |> StockPositionWithCalculations
+    withCalculation.AverageCostPerShare |> should equal 7.5m
+    withCalculation.Cost |> should equal 15m
+    
+    let sell1 = StockPosition.sell 1m 6m DateTimeOffset.UtcNow purchase1
+    let withCalculation = sell1 |> StockPositionWithCalculations
+    withCalculation.AverageCostPerShare |> should equal 10m
+    withCalculation.Cost |> should equal 10m
+    
+    let purchase2 = StockPosition.buy 1m 10m DateTimeOffset.UtcNow sell1
+    let withCalculation = purchase2 |> StockPositionWithCalculations
+    withCalculation.AverageCostPerShare |> should equal 10m
+    withCalculation.Cost |> should equal 20m
+    
+    let sell2 = StockPosition.sell 2m 10m DateTimeOffset.UtcNow purchase2
+    sell2.IsClosed |> should equal true
+    let withCalculation = sell2 |> StockPositionWithCalculations
+    DateTimeOffset.UtcNow.Subtract(withCalculation.Closed.Value).TotalSeconds |> int |> should be (lessThan 1)
+    withCalculation.DaysHeld |> should equal 0
+    withCalculation.Profit |> should equal 1
+    
+    Assert.Equal(0.04m, withCalculation.GainPct, 2)
+    
+[<Fact>]
+let ``Sell creates PL Transactions`` () =
+    
+    let stock =
+        StockPosition.openLong ticker DateTimeOffset.UtcNow
+        |> StockPosition.buy 1m 5m DateTimeOffset.UtcNow
+        |> StockPosition.buy 1m 10m DateTimeOffset.UtcNow 
+        |> StockPosition.sell 1m 6m DateTimeOffset.UtcNow
+        |> StockPosition.buy 1m 10m DateTimeOffset.UtcNow
+        |> StockPosition.sell 2m 10m DateTimeOffset.UtcNow
+        |> StockPositionWithCalculations
+        
+    let transactions = stock.PLTransactions
+    
+    transactions |> should haveLength 2
+    
+    transactions |> List.head |> _.Profit |> should equal 1m
+    transactions |> List.last |> _.Profit |> should equal 0m
+    
+    
+[<Fact>]
+let ``Days held is correct`` () =
+    
+    let position =
+        StockPosition.openLong ticker (DateTimeOffset.UtcNow.AddDays(-5))
+        |> StockPosition.buy 1m 5m (DateTimeOffset.UtcNow.AddDays(-5))
+        |> StockPosition.buy 1m 10m (DateTimeOffset.UtcNow.AddDays(-2))
+        
+    let calculated = position |> StockPositionWithCalculations
+    
+    calculated.DaysHeld |> should equal 5
+    calculated.DaysSinceLastTransaction |> should equal 2
+    
+    let afterSell1 = position |> StockPosition.sell 1m 6m DateTimeOffset.UtcNow
+    
+    let calculated = afterSell1 |> StockPositionWithCalculations
+    
+    calculated.DaysHeld |> should equal 5
+    calculated.DaysSinceLastTransaction |> should equal 0
+ 

--- a/tests/coretests.fs/coretests.fs.fsproj
+++ b/tests/coretests.fs/coretests.fs.fsproj
@@ -9,7 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="Stocks\StockPositionTests.fs" />
+    <Compile Include="Stocks\StockPositionLongTests.fs" />
+    <Compile Include="Stocks\StockPositionShortTests.fs" />
     <Compile Include="Stocks\StockPositionWithCalculationsTests.fs" />
     <Compile Include="Stocks\PriceBarTests.fs" />
     <Compile Include="Stocks\PricesViewTests.fs" />

--- a/tests/coretests/Alerts/ScanSchedulingTests.cs
+++ b/tests/coretests/Alerts/ScanSchedulingTests.cs
@@ -3,7 +3,6 @@ using core.fs.Alerts;
 using core.fs.Adapters.Brokerage;
 using core.fs.Adapters.Logging;
 using core.fs.Adapters.Storage;
-using core.fs.Adapters.Storage;
 using Moq;
 using Xunit;
 


### PR DESCRIPTION
It was close to impossible to have a clean support for short positions in V2. Now that we have V3 models, short position implementation is pretty straightforward.

The short position is modeled with the same open position event, but with type set to short. When UI wants to provide an interface to open a short position, the number of shares to open a short needs to be a negative value. Much of the remaining code stays the same. The one thing that you can't rely on anymore is buys coming before sells and things like that. I introduced a new concept of "acquisition" and "liquidation" steps where position is acquired and liquidated. You acquire long by buying and short by selling. And liquidation is opposite.

I will feel out how the calculations will feel with the negative numbers and what not, but this should be a great starting point.