### PR TITLE
Add brokerage support for shorting

### DIFF
--- a/src/core.fs/Adapters/Brokerage.fs
+++ b/src/core.fs/Adapters/Brokerage.fs
@@ -213,7 +213,9 @@ type IBrokerage =
     abstract member RefreshAccessToken : state:UserState -> Task<OAuthResponse>
     abstract member GetAccount : state:UserState -> Task<ServiceResponse<TradingAccount>>
     abstract member BuyOrder : state:UserState -> ticker:Ticker -> numberOfShares:decimal -> price:decimal -> ``type``:BrokerageOrderType -> duration:BrokerageOrderDuration -> Task<ServiceResponse<bool>>
+    abstract member BuyToCoverOrder : state:UserState -> ticker:Ticker -> numberOfShares:decimal -> price:decimal -> ``type``:BrokerageOrderType -> duration:BrokerageOrderDuration -> Task<ServiceResponse<bool>>
     abstract member SellOrder : state:UserState -> ticker:Ticker -> numberOfShares:decimal -> price:decimal -> ``type``:BrokerageOrderType -> duration:BrokerageOrderDuration -> Task<ServiceResponse<bool>>
+    abstract member SellShortOrder : state:UserState -> ticker:Ticker -> numberOfShares:decimal -> price:decimal -> ``type``:BrokerageOrderType -> duration:BrokerageOrderDuration -> Task<ServiceResponse<bool>>
     abstract member CancelOrder : state:UserState -> orderId:string -> Task<ServiceResponse<bool>>
     abstract member GetQuote : state:UserState -> ticker:Ticker -> Task<ServiceResponse<StockQuote>>
     abstract member GetQuotes : state:UserState -> tickers:Ticker seq -> Task<ServiceResponse<Dictionary<Ticker, StockQuote>>>

--- a/src/core.fs/Alerts/MonitoringServices.fs
+++ b/src/core.fs/Alerts/MonitoringServices.fs
@@ -185,14 +185,14 @@ module core.fs.Alerts.MonitoringServices
                     ownedStocks
                     |> Seq.filter (_.IsOpen)
                     |> Seq.map (_.Ticker)
-                    |> Seq.map (fun t -> {ticker=t; listName="Portfolio"; user=user.State})
+                    |> Seq.map (fun t -> {ticker=t; listName=Constants.PortfolioIdentifier; user=user.State})
                     
                 let! pendingPositions = emailIdPair.Id |> portfolio.GetPendingStockPositions |> Async.AwaitTask
                 let pendingList =
                     pendingPositions
                     |> Seq.filter (fun p -> p.State.IsClosed |> not)
                     |> Seq.map (_.State.Ticker)
-                    |> Seq.map (fun t -> {ticker=t; listName="Pending"; user=user.State})
+                    |> Seq.map (fun t -> {ticker=t; listName=Constants.PendingIdentifier; user=user.State})
                 
                 let! lists = emailIdPair.Id |> portfolio.GetStockLists |> Async.AwaitTask
                 return lists

--- a/src/core.fs/Alerts/Types.fs
+++ b/src/core.fs/Alerts/Types.fs
@@ -39,6 +39,8 @@ namespace core.fs.Alerts
         let MonitorTagPattern = "monitor:patterns"
         let MonitorNamePattern = "Patterns"
         let StopLossIdentifier = "Stop loss"
+        let PortfolioIdentifier = "💼 Portfolio"
+        let PendingIdentifier = "⏳ Pending"
     
     
     [<Struct>]

--- a/src/core.fs/ImportTransactions.fs
+++ b/src/core.fs/ImportTransactions.fs
@@ -66,7 +66,7 @@ module ImportTransactions =
         emailService:IEmailService,
         csvParser:ICSVParser,
         optionsImport:core.fs.Options.Handler,
-        stocksImport:core.fs.Portfolio.Handler) =
+        stocksImport:core.fs.Portfolio.StockPositionHandler) =
         
         interface IApplicationService
         

--- a/src/core.fs/core.fs.fsproj
+++ b/src/core.fs/core.fs.fsproj
@@ -47,10 +47,10 @@
         <Compile Include="Cryptos\Handlers.fs"/>
         <Compile Include="Portfolio\Views.fs"/>
         <Compile Include="Portfolio\Helpers.fs" />
-        <Compile Include="Portfolio\Handler.fs" />
+        <Compile Include="Portfolio\StockPositionHandler.fs" />
         <Compile Include="Reports\Handlers.fs"/>
         <Compile Include="Stocks\ListsHandler.fs" />
-        <Compile Include="Stocks\PendingPositionsHandler.fs" />
+        <Compile Include="Stocks\PendingStockPositionsHandler.fs" />
         <Compile Include="Stocks\StocksHandler.fs" />
         <Compile Include="ImportTransactions.fs"/>
         <Compile Include="Routines\Handler.fs" />

--- a/src/core/Stocks/PendingStockPosition.cs
+++ b/src/core/Stocks/PendingStockPosition.cs
@@ -29,11 +29,6 @@ namespace core.Stocks
                 throw new InvalidOperationException("Price cannot be negative or zero");
             }
 
-            if (numberOfShares <= 0)
-            {
-                throw new InvalidOperationException("Number of shares cannot be negative or zero");
-            }
-
             if (stopPrice.HasValue && stopPrice.Value < 0)
             {
                 throw new InvalidOperationException("Stop price cannot be negative or zero");

--- a/src/core/Stocks/PendingStockPosition.cs
+++ b/src/core/Stocks/PendingStockPosition.cs
@@ -28,6 +28,11 @@ namespace core.Stocks
             {
                 throw new InvalidOperationException("Price cannot be negative or zero");
             }
+            
+            if (numberOfShares == 0)
+            {
+                throw new InvalidOperationException("Number of shares cannot be zero");
+            }
 
             if (stopPrice.HasValue && stopPrice.Value < 0)
             {

--- a/src/infrastructure/tdameritradeclient/TDAmeritradeClient.cs
+++ b/src/infrastructure/tdameritradeclient/TDAmeritradeClient.cs
@@ -336,6 +336,68 @@ public class TDAmeritradeClient : IBrokerage
 
         return EnterOrder(user, postData);
     }
+    
+    public Task<ServiceResponse<bool>> BuyToCoverOrder(
+        UserState user,
+        Ticker ticker,
+        decimal numberOfShares,
+        decimal price,
+        BrokerageOrderType type,
+        BrokerageOrderDuration duration)
+    {
+        var legCollection = new {
+            instruction = "BUY_TO_COVER",
+            quantity = numberOfShares,
+            instrument = new {
+                symbol = ticker.Value,
+                assetType = "EQUITY"
+            }
+        };
+
+        var postData = new
+        {
+            orderType = GetBuyOrderType(type),
+            session = GetSession(duration),
+            duration = GetBuyOrderDuration(duration),
+            price = GetPrice(type, price),
+            stopPrice = GetActivationPrice(type, price),
+            orderStrategyType = "SINGLE",
+            orderLegCollection = new [] {legCollection}
+        };
+
+        return EnterOrder(user, postData);
+    }
+    
+    public Task<ServiceResponse<bool>> SellShortOrder(
+        UserState user,
+        Ticker ticker,
+        decimal numberOfShares,
+        decimal price,
+        BrokerageOrderType type,
+        BrokerageOrderDuration duration)
+    {
+        var legCollection = new {
+            instruction = "SELL_SHORT",
+            quantity = numberOfShares,
+            instrument = new {
+                symbol = ticker.Value,
+                assetType = "EQUITY"
+            }
+        };
+
+        var postData = new
+        {
+            orderType = GetBuyOrderType(type),
+            session = GetSession(duration),
+            duration = GetBuyOrderDuration(duration),
+            price = GetPrice(type, price),
+            stopPrice = GetActivationPrice(type, price),
+            orderStrategyType = "SINGLE",
+            orderLegCollection = new [] {legCollection}
+        };
+
+        return EnterOrder(user, postData);
+    }
 
     public Task<ServiceResponse<bool>> SellOrder(
         UserState user,

--- a/src/web/ClientApp/src/app/services/stockpositions.service.ts
+++ b/src/web/ClientApp/src/app/services/stockpositions.service.ts
@@ -63,6 +63,10 @@ export class StockPositionsService {
     return this.http.delete(`/api/portfolio/stockpositions/${positionId}`)
   }
 
+  closePosition(positionId:string): Observable<object>{
+    return this.http.post(`/api/portfolio/stockpositions/${positionId}/close`, {positionId})
+  }
+
   setLabel(positionId:string, label: KeyValuePair): Observable<object> {
     return this.http.post(`/api/portfolio/stockpositions/${positionId}/labels`, {
       key: label.key,

--- a/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-position.component.html
+++ b/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-position.component.html
@@ -127,7 +127,10 @@
   </div>
   <div class="row mt-3">
     <div class="col">
-      <button class="btn btn-sm btn-outline-danger" (click)="deletePosition()">Delete</button>
+      <button class="btn btn-sm btn-outline-secondary" (click)="closePosition()">Close</button>
+    </div>
+    <div class="col">
+      <button class="btn btn-sm btn-outline-danger float-end" (click)="deletePosition()">Delete</button>
     </div>
   </div>
 </div>

--- a/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-position.component.ts
+++ b/src/web/ClientApp/src/app/stocks/stock-trading/stock-trading-position.component.ts
@@ -137,6 +137,25 @@ export class StockTradingPositionComponent {
           (_) => {
             this._position = null
             this.positionDeleted.emit()
+          },
+          err => {
+            let errors = GetErrors(err)
+            alert("Error deleting position: " + errors.join(", "))
+          })
+    }
+  }
+
+  closePosition() {
+    if (confirm("Are you sure you want to close this position?")) {
+      this.stockService.closePosition(this._position.positionId)
+        .subscribe(
+          (_) => {
+            this._position = null
+            this.positionDeleted.emit()
+          },
+          err => {
+            let errors = GetErrors(err)
+            alert("Error closing position: " + errors.join(", "))
           })
     }
   }

--- a/src/web/Controllers/PendingPositionsController.cs
+++ b/src/web/Controllers/PendingPositionsController.cs
@@ -12,28 +12,28 @@ namespace web.Controllers;
 [Route("api/stocks/pendingpositions")]
 public class PendingPositionsController : ControllerBase
 {
-    private readonly Handler _handler;
-    public PendingPositionsController(Handler handler) => _handler = handler;
+    private readonly PendingStockPositionsHandler _pendingStockPositionsHandler;
+    public PendingPositionsController(PendingStockPositionsHandler pendingStockPositionsHandler) => _pendingStockPositionsHandler = pendingStockPositionsHandler;
     
     [HttpGet]
     public Task<ActionResult> PendingStockPositions() =>
-        this.OkOrError(_handler.Handle(new Query(User.Identifier())));
+        this.OkOrError(_pendingStockPositionsHandler.Handle(new Query(User.Identifier())));
         
     [HttpGet("export")]
     public Task<ActionResult> ExportPendingStockPositions() =>
         this.GenerateExport(
-            _handler.Handle(new Export(User.Identifier())
+            _pendingStockPositionsHandler.Handle(new Export(User.Identifier())
             ));
         
     [HttpPost]
     public Task<ActionResult> CreatePendingStockPosition([FromBody]Create command) =>
         this.OkOrError(
-            _handler.HandleCreate(
+            _pendingStockPositionsHandler.HandleCreate(
                 User.Identifier(), command
             )
         );
 
     [HttpDelete("{id}")]
     public Task<ActionResult> ClosePendingStockPosition([FromRoute] Guid id) =>
-        this.OkOrError(_handler.Handle(new Close(id, User.Identifier())));
+        this.OkOrError(_pendingStockPositionsHandler.Handle(new Close(id, User.Identifier())));
 }

--- a/tests/coretests/Stocks/PendingStockPositionTests.cs
+++ b/tests/coretests/Stocks/PendingStockPositionTests.cs
@@ -60,6 +60,21 @@ namespace coretests.Stocks
                 ticker: TestDataGenerator.AMD,
                 userId: Guid.NewGuid()));
         }
+        
+        [Fact]
+        public void Create_WithNegativeNumberOfSharesForShortPositions_Works()
+        {
+            var position = new PendingStockPosition(
+                notes: "this is a note",
+                numberOfShares: -10,
+                price: 10,
+                stopPrice: 5,
+                strategy: "alltimehigh",
+                ticker: TestDataGenerator.AMD,
+                userId: Guid.NewGuid());
+            
+            Assert.Equal(-10, position.State.NumberOfShares);
+        }
 
         [Fact]
         public void Create_WithInvalidStopPrice_Throws()


### PR DESCRIPTION
Previously I added short position support for internal storage but still didn't have the ability to open and close short positions with the brokerage. This PR adds that functionality, plus some rename refactoring, and more standing out names for Portfolio and Pending stock lists on the alerts pages.