### PR TITLE
Trade recommendations

### DIFF
--- a/src/core.fs/Reports/Handlers.fs
+++ b/src/core.fs/Reports/Handlers.fs
@@ -11,10 +11,8 @@ open core.fs.Adapters.Stocks
 open core.fs.Adapters.Storage
 open core.fs.Services
 open core.fs.Services.Analysis
-open core.fs.Services.Analysis.SingleBarPriceAnalysis
 open core.fs.Services.GapAnalysis
 open core.fs.Services.MultipleBarPriceAnalysis
-open core.fs.Adapters.Storage
 open core.fs.Stocks
 
 type ChainQuery =
@@ -294,7 +292,7 @@ type Handler(accounts:IAccountStorage,brokerage:IBrokerage,marketHours:IMarketHo
             match priceResponse.Success with
             | None -> return priceResponse.Error.Value.Message |> ResponseUtils.failedTyped<GapReportView>
             | Some prices ->
-                let gaps = detectGaps prices Constants.NumberOfDaysForRecentAnalysis
+                let gaps = prices |> detectGaps Constants.NumberOfDaysForRecentAnalysis
                 let response = {gaps=gaps; ticker=query.Ticker.Value}
                 return ServiceResponse<GapReportView>(response)
     }
@@ -344,7 +342,7 @@ type Handler(accounts:IAccountStorage,brokerage:IBrokerage,marketHours:IMarketHo
                             let gapsView =
                                 match query.IncludeGapAnalysis with
                                 | true ->
-                                    let gaps = detectGaps prices Constants.NumberOfDaysForRecentAnalysis
+                                    let gaps = prices |> detectGaps Constants.NumberOfDaysForRecentAnalysis
                                     Some {gaps=gaps; ticker=t.Value}
                                 | false -> None
                                 

--- a/src/core.fs/Services/GapAnalysis.fs
+++ b/src/core.fs/Services/GapAnalysis.fs
@@ -91,7 +91,7 @@ let private generateInternal (prices: PriceBars) (volumeStats: core.fs.Services.
         }
     )
     
-let detectGaps (prices: PriceBars) (numberOfBarsToAnalyze: int) =
+let detectGaps (numberOfBarsToAnalyze: int) (prices: PriceBars) =
     
     let barsForAnalysis = numberOfBarsToAnalyze |> prices.LatestOrAll
     let barsForVolume = Constants.NumberOfDaysForRecentAnalysis |> prices.LatestOrAll 

--- a/src/core.fs/Services/PatternDetection.fs
+++ b/src/core.fs/Services/PatternDetection.fs
@@ -27,7 +27,7 @@ let gapDown (bars: PriceBars) =
     match bars.Length with
     | 0 | 1 -> None
     | _ ->
-        let gaps = detectGaps bars 2
+        let gaps = bars |> detectGaps 2
         match gaps with
         | [|gap|] when gap.Type = GapType.Down ->
             let relativeVolume = gap.RelativeVolume |> toVolumeMultiplierString
@@ -48,7 +48,7 @@ let gapUp (bars: PriceBars) =
     match bars.Length with
     | 0 | 1 -> None
     | _ ->
-        let gaps = detectGaps bars 2
+        let gaps = bars |> detectGaps 2
         match gaps with
         | [|gap|] when gap.Type = GapType.Up ->
             let relativeVolume = gap.RelativeVolume |> toVolumeMultiplierString

--- a/src/core.fs/Services/SingleBarPriceAnalysis.fs
+++ b/src/core.fs/Services/SingleBarPriceAnalysis.fs
@@ -98,7 +98,7 @@ module SingleBarPriceAnalysis =
                 
                 
             // see if there was a gap down or gap up
-            let gaps = GapAnalysis.detectGaps bars Constants.NumberOfDaysForRecentAnalysis
+            let gaps = bars |> GapAnalysis.detectGaps Constants.NumberOfDaysForRecentAnalysis
             
             let gap = gaps |> Seq.tryFind _.Bar.Equals(currentBar)
             

--- a/src/studies/PriceTransformation.fs
+++ b/src/studies/PriceTransformation.fs
@@ -107,7 +107,7 @@ let transform (brokerage:IGetPriceHistory) studiesDirectory signals = async {
         |> Map.keys
         |> Seq.collect (fun ticker ->
             let bars, _ = prices[ticker]
-            let gaps = detectGaps bars bars.Length
+            let gaps = bars |> detectGaps bars.Length
             gaps
             |> Array.map (fun (g:Gap) ->
                 let gapKey = (ticker, g.Bar.DateStr)

--- a/src/web/ClientApp/src/app/app.module.ts
+++ b/src/web/ClientApp/src/app/app.module.ts
@@ -96,6 +96,7 @@ import {PageNotFoundComponent} from "./page-not-found/page-not-found.component";
 import {InflectionPointsComponent} from "./playground/inflectionpoints.component";
 import {LoadingComponent} from "./shared/loading/loading.component";
 import {BrokerageAccountComponent} from "./brokerage/brokerage-account.component";
+import {TradesReportComponent} from "./reports/trades-report/trades-report.component";
 
 
 let routes: Routes = [
@@ -140,7 +141,7 @@ let routes: Routes = [
 
   {path: 'stocks/lists', component: StockListsDashboardComponent, canActivate: [AuthGuard], title: 'Stock Lists'},
   {path: 'stocks/lists/:name', component: StockListComponent, canActivate: [AuthGuard], title: 'Stock Lists'},
-  {path: 'stocks/newposition', component: StockNewPositionComponent, canActivate: [AuthGuard]},
+  {path: 'stocks/newposition', component: StockNewPositionComponent, canActivate: [AuthGuard], title: 'New Position'},
   {path: 'stocks/:ticker', component: StockDetailsComponent, canActivate: [AuthGuard]},
   {path: 'stocks/:ticker/:tab', component: StockDetailsComponent, canActivate: [AuthGuard]},
 
@@ -152,6 +153,7 @@ let routes: Routes = [
   {path: 'reports/recentsells', component: RecentSellsComponent, canActivate: [AuthGuard], title: 'Recent Sells'},
   {path: 'reports/outcomes', component: OutcomesReportComponent, canActivate: [AuthGuard], title: 'Outcomes Report'},
   {path: 'reports/gaps', component: GapsReportComponent, canActivate: [AuthGuard], title : 'Gaps Report'},
+    {path: 'reports/trades', component: TradesReportComponent, canActivate: [AuthGuard], title: 'Trades Report'},
 
   {path: 'routines', component: RoutineDashboardComponent, canActivate: [AuthGuard], title: 'Routines'},
   {path: 'routines/:name/:mode', component: RoutineComponent, canActivate: [AuthGuard], title: 'Routines'},
@@ -242,6 +244,7 @@ let routes: Routes = [
     GapsComponent,
     PercentChangeDistributionComponent,
     DailyOutcomeScoresComponent,
+      TradesReportComponent,
 
     AlertsComponent,
     StockNewPositionComponent,

--- a/src/web/ClientApp/src/app/playground/playground.component.ts
+++ b/src/web/ClientApp/src/app/playground/playground.component.ts
@@ -50,6 +50,17 @@ export class PlaygroundComponent implements OnInit {
         this.errors = GetErrors(error)
       })
     )
+      
+      let multiBarDaily = this.stocks.reportOutcomesAllBars(this.tickers).pipe(
+          tap((data) => {
+          this.status = "Multi bar daily done"
+          console.log("Multi bar daily")
+          console.log(data)
+        }, (error) => {
+          console.log("Multi bar daily error")
+          this.errors = GetErrors(error)
+        })
+      )
 
     let singleBarWeekly = this.stocks.reportOutcomesSingleBarWeekly(this.tickers).pipe(
       tap((data) => {
@@ -69,7 +80,7 @@ export class PlaygroundComponent implements OnInit {
 
     this.status = "Running..."
 
-    concat(positionReport, gapReport, singleBarDaily, singleBarWeekly).subscribe(
+    concat(positionReport, gapReport, singleBarDaily, singleBarWeekly, multiBarDaily).subscribe(
       (_) => {
         // this.status = "Done"
         // console.log("Done")

--- a/src/web/ClientApp/src/app/reports/trades-report/trades-report.component.html
+++ b/src/web/ClientApp/src/app/reports/trades-report/trades-report.component.html
@@ -1,17 +1,31 @@
 <div>
     <app-error-display [errors]="errors"></app-error-display>
     
-    @for (tradeRecommendation of tradeRecommendations) {
+    @for (tradeRecommendation of tradeRecommendations; track tradeRecommendation.recommendation) {
     <section>
         <h3><span>{{tradeRecommendation.recommendation}}</span></h3>
         
         @if (tradeRecommendation.matchingOutcomes.length > 0) {
-        <app-outcomes [outcomes]="tradeRecommendation.matchingOutcomes"></app-outcomes>
+            <div>Cycles:
+                @for (cycle of tradeRecommendation.cycles; track cycle) {
+                    <span class="badge bg-positive" >{{cycle}}</span>
+                }
+            </div>
+            
+            <ul>
+                @for (note of tradeRecommendation.notes; track note) {
+                    <li>{{note}}</li>
+                } @empty {
+                    <li>No notes</li>
+                }
+            </ul>
+            
+            <app-outcomes [outcomes]="tradeRecommendation.matchingOutcomes"></app-outcomes>
         } @else {
-        No matching outcomes found
+            No matching outcomes found
         }
     </section>
-    } @else {
+    } @empty {
         <app-loading></app-loading>
     }
 </div>

--- a/src/web/ClientApp/src/app/reports/trades-report/trades-report.component.html
+++ b/src/web/ClientApp/src/app/reports/trades-report/trades-report.component.html
@@ -1,7 +1,7 @@
 <div>
     <app-error-display [errors]="errors"></app-error-display>
     
-    @if(tradeRecommendation) {
+    @for (tradeRecommendation of tradeRecommendations) {
     <section>
         <h3><span>{{tradeRecommendation.recommendation}}</span></h3>
         

--- a/src/web/ClientApp/src/app/reports/trades-report/trades-report.component.html
+++ b/src/web/ClientApp/src/app/reports/trades-report/trades-report.component.html
@@ -1,0 +1,17 @@
+<div>
+    <app-error-display [errors]="errors"></app-error-display>
+    
+    @if(tradeRecommendation) {
+    <section>
+        <h3><span>{{tradeRecommendation.recommendation}}</span></h3>
+        
+        @if (tradeRecommendation.matchingOutcomes.length > 0) {
+        <app-outcomes [outcomes]="tradeRecommendation.matchingOutcomes"></app-outcomes>
+        } @else {
+        No matching outcomes found
+        }
+    </section>
+    } @else {
+        <app-loading></app-loading>
+    }
+</div>

--- a/src/web/ClientApp/src/app/reports/trades-report/trades-report.component.spec.ts
+++ b/src/web/ClientApp/src/app/reports/trades-report/trades-report.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TradesReportComponent } from './trades-report.component';
+
+describe('TradesReportComponent', () => {
+  let component: TradesReportComponent;
+  let fixture: ComponentFixture<TradesReportComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TradesReportComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(TradesReportComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/web/ClientApp/src/app/reports/trades-report/trades-report.component.ts
+++ b/src/web/ClientApp/src/app/reports/trades-report/trades-report.component.ts
@@ -1,0 +1,86 @@
+import {Component, OnInit} from '@angular/core';
+import {ActivatedRoute} from "@angular/router";
+import {OutcomesReport, StocksService, TickerOutcomes} from "../../services/stocks.service";
+import {GetErrors} from "../../services/utils";
+
+// this function will return tickers that match the new low trade candidates for buy side
+
+export type TradeRecommendation = {
+    recommendation: string
+    matchingOutcomes: TickerOutcomes[]
+} 
+
+function getNewLowTradeCandidates(report:OutcomesReport): TradeRecommendation {
+    let matchingOutcomes = report.outcomes.filter(outcome => {
+        let currentPrice = outcome.outcomes.find(o => o.key === 'CurrentPrice').value
+        let sma200 = outcome.outcomes.find(o => o.key === 'sma_200').value
+        let sma20 = outcome.outcomes.find(o => o.key === 'sma_20').value
+        
+        return currentPrice > sma200 && currentPrice > sma20
+    })
+    
+    // return trade recommendation instance
+    return {
+        recommendation: 'Buy New Low when current price is above sma200 and sma20',
+        matchingOutcomes: matchingOutcomes
+    }
+}
+
+function selectFunctionToUse(screenerId:string) {
+    switch (screenerId) {
+        case '31':
+            return getNewLowTradeCandidates
+        default:
+            return (_:OutcomesReport) => {
+                return {
+                    recommendation: 'No recommendation',
+                    matchingOutcomes: []
+                }
+            }
+    }
+}
+
+@Component({
+  selector: 'app-trades-report',
+  templateUrl: './trades-report.component.html',
+  styleUrl: './trades-report.component.css'
+})
+export class TradesReportComponent implements OnInit {
+    tickers: string[];
+    errors: string[];
+    screenerId: string;
+    tradeRecommendation: TradeRecommendation
+    
+    constructor(private route: ActivatedRoute, private service: StocksService) {}
+    
+    ngOnInit() {
+        // we must get screenerId parameter from the route, if it's not there, set the error informing the user
+        if (!this.route.snapshot.queryParamMap.has('screenerId')) {
+            this.errors = ['Screener Id is missing']
+            return
+        }
+        
+        this.screenerId = this.route.snapshot.queryParamMap.get('screenerId')
+        
+        // we must get tickers parameter from the route, if it's not there, set the error informing the user
+        if (!this.route.snapshot.queryParamMap.has('tickers')) {
+            this.errors = ['No tickers provided']
+            return
+        }
+        
+        this.tickers = this.route.snapshot.queryParamMap.get('tickers').split(',')
+        
+        let func = selectFunctionToUse(this.screenerId)
+        
+        // multiple bar daily report
+        this.service.reportOutcomesAllBars(this.tickers).subscribe(
+            report => {
+                console.log(report)
+                this.tradeRecommendation = func(report)
+            },
+            error => {
+                this.errors = GetErrors(error)
+            }
+        )
+    }
+}

--- a/tests/coretests.fs/Stocks/Services/GapAnalysisTests.fs
+++ b/tests/coretests.fs/Stocks/Services/GapAnalysisTests.fs
@@ -7,9 +7,8 @@ open testutils
 open FsUnit
 
 let gaps =
-    GapAnalysis.detectGaps
-        (TestDataGenerator.PriceBars(TestDataGenerator.NET))
-        Constants.NumberOfDaysForRecentAnalysis
+    TestDataGenerator.PriceBars(TestDataGenerator.NET)
+    |> GapAnalysis.detectGaps Constants.NumberOfDaysForRecentAnalysis
 
 
 [<Fact>]


### PR DESCRIPTION
This is a POC of a page that given a list of tickers and some other params would run through a set of rules and give trade recommendations, ie. tickers to take a look a bit closer and consider for a trade.

Right now rules are hardcoded on the client side. Those would need to come from user configuration somewhere if I wanted to make it configurable per user.