### PR TITLE
Result conversion

### DIFF
--- a/src/core.fs/Adapters/Brokerage.fs
+++ b/src/core.fs/Adapters/Brokerage.fs
@@ -208,7 +208,7 @@ type IMarketHours =
 
 type IBrokerageGetPriceHistory =
     
-    abstract member GetPriceHistory : state:UserState -> ticker:Ticker -> frequency:PriceFrequency -> start:DateTimeOffset -> ``end``:DateTimeOffset -> Task<ServiceResponse<PriceBars>>
+    abstract member GetPriceHistory : state:UserState -> ticker:Ticker -> frequency:PriceFrequency -> start:DateTimeOffset -> ``end``:DateTimeOffset -> Task<Result<PriceBars,ServiceError>>
     
 type IBrokerage =
     inherit IBrokerageGetPriceHistory
@@ -216,15 +216,15 @@ type IBrokerage =
     abstract member ConnectCallback : code:string -> Task<OAuthResponse>
     abstract member GetAccessToken : state:UserState -> Task<OAuthResponse>
     abstract member RefreshAccessToken : state:UserState -> Task<OAuthResponse>
-    abstract member GetAccount : state:UserState -> Task<ServiceResponse<BrokerageAccount>>
-    abstract member BuyOrder : state:UserState -> ticker:Ticker -> numberOfShares:decimal -> price:decimal -> ``type``:BrokerageOrderType -> duration:BrokerageOrderDuration -> Task<ServiceResponse<bool>>
-    abstract member BuyToCoverOrder : state:UserState -> ticker:Ticker -> numberOfShares:decimal -> price:decimal -> ``type``:BrokerageOrderType -> duration:BrokerageOrderDuration -> Task<ServiceResponse<bool>>
-    abstract member SellOrder : state:UserState -> ticker:Ticker -> numberOfShares:decimal -> price:decimal -> ``type``:BrokerageOrderType -> duration:BrokerageOrderDuration -> Task<ServiceResponse<bool>>
-    abstract member SellShortOrder : state:UserState -> ticker:Ticker -> numberOfShares:decimal -> price:decimal -> ``type``:BrokerageOrderType -> duration:BrokerageOrderDuration -> Task<ServiceResponse<bool>>
-    abstract member CancelOrder : state:UserState -> orderId:string -> Task<ServiceResponse<bool>>
-    abstract member GetQuote : state:UserState -> ticker:Ticker -> Task<ServiceResponse<StockQuote>>
-    abstract member GetQuotes : state:UserState -> tickers:Ticker seq -> Task<ServiceResponse<Dictionary<Ticker, StockQuote>>>
-    abstract member GetMarketHours : state:UserState -> start:DateTimeOffset -> Task<ServiceResponse<MarketHours>>
-    abstract member Search : state:UserState -> query:string -> limit:int -> Task<ServiceResponse<SearchResult[]>>
-    abstract member GetOptions : state:UserState -> ticker:Ticker -> expirationDate:DateTimeOffset option -> strikePrice:decimal option -> contractType:string option -> Task<ServiceResponse<OptionChain>>
-    abstract member GetStockProfile : state:UserState -> ticker:Ticker -> Task<ServiceResponse<StockProfile>>
+    abstract member GetAccount : state:UserState -> Task<Result<BrokerageAccount,ServiceError>>
+    abstract member BuyOrder : state:UserState -> ticker:Ticker -> numberOfShares:decimal -> price:decimal -> ``type``:BrokerageOrderType -> duration:BrokerageOrderDuration -> Task<Result<unit,ServiceError>>
+    abstract member BuyToCoverOrder : state:UserState -> ticker:Ticker -> numberOfShares:decimal -> price:decimal -> ``type``:BrokerageOrderType -> duration:BrokerageOrderDuration -> Task<Result<unit,ServiceError>>
+    abstract member SellOrder : state:UserState -> ticker:Ticker -> numberOfShares:decimal -> price:decimal -> ``type``:BrokerageOrderType -> duration:BrokerageOrderDuration -> Task<Result<unit,ServiceError>>
+    abstract member SellShortOrder : state:UserState -> ticker:Ticker -> numberOfShares:decimal -> price:decimal -> ``type``:BrokerageOrderType -> duration:BrokerageOrderDuration -> Task<Result<unit,ServiceError>>
+    abstract member CancelOrder : state:UserState -> orderId:string -> Task<Result<unit,ServiceError>>
+    abstract member GetQuote : state:UserState -> ticker:Ticker -> Task<Result<StockQuote,ServiceError>>
+    abstract member GetQuotes : state:UserState -> tickers:Ticker seq -> Task<Result<Dictionary<Ticker, StockQuote>,ServiceError>>
+    abstract member GetMarketHours : state:UserState -> start:DateTimeOffset -> Task<Result<MarketHours,ServiceError>>
+    abstract member Search : state:UserState -> query:string -> limit:int -> Task<Result<SearchResult[],ServiceError>>
+    abstract member GetOptions : state:UserState -> ticker:Ticker -> expirationDate:DateTimeOffset option -> strikePrice:decimal option -> contractType:string option -> Task<Result<OptionChain,ServiceError>>
+    abstract member GetStockProfile : state:UserState -> ticker:Ticker -> Task<Result<StockProfile,ServiceError>>

--- a/src/core.fs/Adapters/CSV.fs
+++ b/src/core.fs/Adapters/CSV.fs
@@ -11,5 +11,5 @@ type ICSVWriter =
     abstract Generate<'T> : rows:seq<'T> -> string
     
 type ICSVParser =
-    abstract Parse<'T> : content:string -> ServiceResponse<seq<'T>>
+    abstract Parse<'T> : content:string -> Result<seq<'T>,ServiceError>
     

--- a/src/core.fs/Adapters/SEC.fs
+++ b/src/core.fs/Adapters/SEC.fs
@@ -33,4 +33,4 @@ type CompanyFilings(ticker:Ticker, filings:seq<CompanyFiling>) =
 
 
 type ISECFilings =
- abstract GetFilings : ticker:Ticker  -> Task<ServiceResponse<CompanyFilings>>
+ abstract GetFilings : ticker:Ticker  -> Task<Result<CompanyFilings,ServiceError>>

--- a/src/core.fs/Admin/Handlers.fs
+++ b/src/core.fs/Admin/Handlers.fs
@@ -48,12 +48,12 @@ type Handler(storage:IAccountStorage, email:IEmailService, portfolio:IPortfolioS
                 
     interface IApplicationService
     
-    member _.Handle (cmd:SendEmail) = task {
+    member _.Handle (cmd:SendEmail) : System.Threading.Tasks.Task<Result<Unit,ServiceError>> = task {
         do! cmd.input |> email.SendWithInput
-        return Ok
+        return Ok()
     }
     
-    member _.Handle sendWelcome = task {
+    member _.Handle sendWelcome : System.Threading.Tasks.Task<Result<Unit,ServiceError>> = task {
         let! user = sendWelcome.userId |> storage.GetUser 
         match user with
         | Some user ->
@@ -65,11 +65,11 @@ type Handler(storage:IAccountStorage, email:IEmailService, portfolio:IPortfolioS
                     
             return Ok ()
             
-        | None -> return "User not found" |> Error
+        | None -> return "User not found" |> ServiceError |> Error
         
     }
             
-    member _.Handle (_:Query) =
+    member _.Handle (_:Query) : System.Threading.Tasks.Task<Result<QueryResponse array,ServiceError>> =
         task {
             let! users = storage.GetUserEmailIdPairs()
             
@@ -79,7 +79,7 @@ type Handler(storage:IAccountStorage, email:IEmailService, portfolio:IPortfolioS
                 |> Async.Parallel
                 |> Async.StartAsTask
                 
-            return result
+            return result |> Ok
         }
         
     member _.Handle (_:Export) = task {

--- a/src/core.fs/Admin/Handlers.fs
+++ b/src/core.fs/Admin/Handlers.fs
@@ -7,7 +7,6 @@ open core.fs.Adapters.CSV
 open core.fs.Adapters.Email
 open core.fs.Adapters.Storage
 open core.fs.Services
-open core.fs.Adapters.Storage
 open core.fs.Stocks
 
 type Query = {
@@ -56,7 +55,6 @@ type Handler(storage:IAccountStorage, email:IEmailService, portfolio:IPortfolioS
     
     member _.Handle sendWelcome = task {
         let! user = sendWelcome.userId |> storage.GetUser 
-        
         match user with
         | Some user ->
             do! email.SendWithTemplate
@@ -65,9 +63,9 @@ type Handler(storage:IAccountStorage, email:IEmailService, portfolio:IPortfolioS
                     EmailTemplate.NewUserWelcome
                     (System.Object())
                     
-            return ServiceResponse.Ok
+            return Ok ()
             
-        | None -> return ResponseUtils.failed "User not found"
+        | None -> return "User not found" |> Error
         
     }
             
@@ -81,7 +79,7 @@ type Handler(storage:IAccountStorage, email:IEmailService, portfolio:IPortfolioS
                 |> Async.Parallel
                 |> Async.StartAsTask
                 
-            return ServiceResponse<QueryResponse seq>(result)
+            return result
         }
         
     member _.Handle (_:Export) = task {
@@ -99,5 +97,5 @@ type Handler(storage:IAccountStorage, email:IEmailService, portfolio:IPortfolioS
             
         let filename = CSVExport.generateFilename "users"
         
-        return ExportResponse(filename, CSVExport.users csvWriter users) |> ResponseUtils.success<ExportResponse>
+        return ExportResponse(filename, CSVExport.users csvWriter users)
     }

--- a/src/core.fs/Alerts/Handlers.fs
+++ b/src/core.fs/Alerts/Handlers.fs
@@ -39,34 +39,32 @@ namespace core.fs.Alerts
 
             let recentlyTriggered = container.GetRecentlyTriggered(query.UserId)
             
-            {| alerts = alerts; recentlyTriggered = recentlyTriggered; messages = container.GetNotices() |}
+            { alerts = alerts; recentlyTriggered = recentlyTriggered; messages = container.GetNotices() }
         
         member this.Handle (_:QueryAvailableMonitors) =
             [
                 {| name = Constants.MonitorNamePattern; tag = Constants.MonitorTagPattern |}
             ]
             
-        member this.Handle (_:Run) =
+        member this.Handle (_:Run) : Result<Unit,ServiceError> =
             // TODO: need to bring this functionality back, it should kick off pattern monitoring run
             Ok ()
       
-        member this.Handle (send:SendSMS) = task {
+        member this.Handle (send:SendSMS) : System.Threading.Tasks.Task<Result<Unit,ServiceError>> = task {
             do! smsService.SendSMS(send.Body)
             return Ok ()
         }
         
-        member this.Handle (_:TurnSMSOn) = task {
-            smsService.TurnOn()
-            return Ok ()
+        member this.Handle (_:TurnSMSOn) : System.Threading.Tasks.Task<Result<Unit,ServiceError>> = task {
+            return smsService.TurnOn() |> Ok
         }
         
-        member this.Handle (_:TurnSMSOff) = task {
-            smsService.TurnOff()
-            return Ok ()
+        member this.Handle (_:TurnSMSOff) : System.Threading.Tasks.Task<Result<Unit,ServiceError>> = task {
+            return smsService.TurnOff() |> Ok
         }
         
-        member this.Handle (_:SMSStatus) = task {
-            return smsService.IsOn
+        member this.Handle (_:SMSStatus) : System.Threading.Tasks.Task<Result<bool, ServiceError>> = task {
+            return smsService.IsOn |> Ok
         }
             
             

--- a/src/core.fs/Alerts/Handlers.fs
+++ b/src/core.fs/Alerts/Handlers.fs
@@ -40,37 +40,33 @@ namespace core.fs.Alerts
             let recentlyTriggered = container.GetRecentlyTriggered(query.UserId)
             
             {| alerts = alerts; recentlyTriggered = recentlyTriggered; messages = container.GetNotices() |}
-            |> ResponseUtils.success
-        
         
         member this.Handle (_:QueryAvailableMonitors) =
-            let available =
-                [
-                    {| name = Constants.MonitorNamePattern; tag = Constants.MonitorTagPattern |}
-                ]
-            available |> ResponseUtils.success
-        
+            [
+                {| name = Constants.MonitorNamePattern; tag = Constants.MonitorTagPattern |}
+            ]
+            
         member this.Handle (_:Run) =
             // TODO: need to bring this functionality back, it should kick off pattern monitoring run
-            Ok
+            Ok ()
       
         member this.Handle (send:SendSMS) = task {
             do! smsService.SendSMS(send.Body)
-            return Ok
+            return Ok ()
         }
         
         member this.Handle (_:TurnSMSOn) = task {
             smsService.TurnOn()
-            return Ok
+            return Ok ()
         }
         
         member this.Handle (_:TurnSMSOff) = task {
             smsService.TurnOff()
-            return Ok
+            return Ok ()
         }
         
         member this.Handle (_:SMSStatus) = task {
-            return smsService.IsOn |> ResponseUtils.success<bool>
+            return smsService.IsOn
         }
             
             

--- a/src/core.fs/Alerts/Types.fs
+++ b/src/core.fs/Alerts/Types.fs
@@ -71,6 +71,12 @@ namespace core.fs.Alerts
                 alertType = pattern.sentimentType
                 valueFormat = pattern.valueFormat
             }
+    
+    type AlertsView = {
+        alerts: TriggeredAlert list
+        recentlyTriggered: TriggeredAlert list
+        messages: AlertContainerMessage seq
+    }
         
     type StockAlertContainer() =
         let alerts = ConcurrentDictionary<StockPositionMonitorKey, TriggeredAlert>()

--- a/src/core.fs/Brokerage/Handlers.fs
+++ b/src/core.fs/Brokerage/Handlers.fs
@@ -64,27 +64,27 @@ type BrokerageHandler(accounts:IAccountStorage, brokerage:IBrokerage) =
         
         match user with
         | None ->
-            return "User not found" |> ResponseUtils.failed 
+            return "User not found" |> ServiceError |> Error 
         | Some user ->
             let! _ = user.State |> func data
-            return Ok
+            return Ok ()
     }
     
     member _.Handle (command:CancelOrder) = task {
         let! user = accounts.GetUser(command.UserId)
         
         match user with
-        | None -> return ResponseUtils.failed "User not found"
+        | None -> return "User not found" |> ServiceError |> Error
         | Some user ->
             let! _ = brokerage.CancelOrder user.State command.OrderId
-            return Ok
+            return Ok ()
     }
     
     member _.Handle (query:QueryAccount) = task {
         let! user = accounts.GetUser(query.UserId)
         
         match user with
-        | None -> return ResponseUtils.failedTyped<BrokerageAccount> "User not found"
+        | None -> return "User not found" |> ServiceError |> Error
         | Some user -> return! brokerage.GetAccount(user.State)
     }
         

--- a/src/core.fs/Brokerage/MonitoringServices.fs
+++ b/src/core.fs/Brokerage/MonitoringServices.fs
@@ -36,7 +36,7 @@ type AccountMonitoringService(
             |> Seq.map (fun user -> async {
                     
                 let! account = brokerage.GetAccount user.State |> Async.AwaitTask
-                match account.Result with
+                match account with
                 | Error e ->
                     logger.LogError $"Unable to get brokerage account for {user.State.Id}: {e.Message}"
                 | Ok account ->

--- a/src/core.fs/Options/Views.fs
+++ b/src/core.fs/Options/Views.fs
@@ -112,10 +112,10 @@ type OptionDashboardView(closed:seq<OwnedOptionView>, ``open``:seq<OwnedOptionVi
     member this.BuyStats = OwnedOptionStats(closed |> Seq.filter (fun s -> s.BoughtOrSold = "Bought"))
     member this.SellStats = OwnedOptionStats(closed |> Seq.filter (fun s -> s.BoughtOrSold = "Sold"))
 
-type OptionDetailsViewModel(price:Nullable<decimal>, chain:OptionChain) =
+type OptionDetailsViewModel(price:decimal option, chain:OptionChain) =
     
     member this.StockPrice = price
     member this.Options = chain.Options
-    member this.Expirations = chain.Options |> Seq.map (fun o -> o.ExpirationDate) |> Seq.distinct |> Seq.toArray
+    member this.Expirations = chain.Options |> Seq.map _.ExpirationDate |> Seq.distinct |> Seq.toArray
     member this.Volatility = chain.Volatility
     member this.NumberOfContracts = chain.NumberOfContracts

--- a/src/core.fs/Portfolio/StockPositionHandler.fs
+++ b/src/core.fs/Portfolio/StockPositionHandler.fs
@@ -3,6 +3,7 @@ namespace core.fs.Portfolio
 open System
 open System.Collections.Generic
 open System.ComponentModel.DataAnnotations
+open System.Threading.Tasks
 open Microsoft.FSharp.Core
 open core.Cryptos
 open core.Options
@@ -505,7 +506,7 @@ type StockPositionHandler(accounts:IAccountStorage,brokerage:IBrokerage,csvWrite
                 return Ok ()
     }
         
-    member this.Handle (query:Query) = task {
+    member this.Handle (query:Query) : Task<Result<PortfolioView,ServiceError>> = task {
         let! stocks = query.UserId |> storage.GetStockPositions
         
         let openStocks = stocks |> Seq.filter _.IsOpen
@@ -860,7 +861,7 @@ type StockPositionHandler(accounts:IAccountStorage,brokerage:IBrokerage,csvWrite
             return tradingEntries |> Ok
     }
     
-    member _.Handle(query:QueryTransactions) = task {
+    member _.Handle(query:QueryTransactions) : Task<Result<TransactionsView, ServiceError>>  = task {
         
         let toSharedTransaction (stock:StockPositionWithCalculations) (plTransaction:PLTransaction) : Transaction =
             Transaction.PLTx(Guid.NewGuid(), stock.Ticker, plTransaction.Ticker.Value, plTransaction.BuyPrice, plTransaction.Profit, plTransaction.Date, false)

--- a/src/core.fs/Portfolio/StockPositionHandler.fs
+++ b/src/core.fs/Portfolio/StockPositionHandler.fs
@@ -254,7 +254,7 @@ type StockPositionHandler(accounts:IAccountStorage,brokerage:IBrokerage,csvWrite
     member _.Handle (query:OwnershipQuery) = task {
         let! user = accounts.GetUser(query.UserId)
         match user with
-        | None -> return "User not found" |> ResponseUtils.failedTyped<{|positions:StockPositionWithCalculations seq|}>
+        | None -> return "User not found" |> ServiceError |> Error
         | Some _ ->
             let! positions = storage.GetStockPositions query.UserId
             let positions =
@@ -263,9 +263,7 @@ type StockPositionHandler(accounts:IAccountStorage,brokerage:IBrokerage,csvWrite
                 |> Seq.sortByDescending _.Opened
                 |> Seq.map StockPositionWithCalculations
                 
-            let obj = {|positions = positions|}
-            
-            return ServiceResponse<{|positions:StockPositionWithCalculations seq|}>(obj)
+            return {|positions = positions|} |> Ok
     }
     
     member _.Handle (query:ExportTransactions) = task {
@@ -274,16 +272,14 @@ type StockPositionHandler(accounts:IAccountStorage,brokerage:IBrokerage,csvWrite
         
         let filename = CSVExport.generateFilename("stocks")
         
-        let response = ExportResponse(filename, CSVExport.stocks csvWriter stocks)
-        
-        return ServiceResponse<ExportResponse>(response)
+        return ExportResponse(filename, CSVExport.stocks csvWriter stocks)
     }
     
     member _.Handle (query:ExportTrades) = task {
         
         let! user = accounts.GetUser(query.UserId)
         match user with
-        | None -> return "User not found" |> ResponseUtils.failedTyped<ExportResponse>
+        | None -> return "User not found" |> ServiceError |> Error
         | _ ->
             let! stocks = storage.GetStockPositions query.UserId
             
@@ -301,9 +297,7 @@ type StockPositionHandler(accounts:IAccountStorage,brokerage:IBrokerage,csvWrite
                 
             let filename = CSVExport.generateFilename("positions")
             
-            let response = ExportResponse(filename, CSVExport.trades CultureUtils.DefaultCulture csvWriter sorted)
-            
-            return ServiceResponse<ExportResponse>(response)
+            return ExportResponse(filename, CSVExport.trades CultureUtils.DefaultCulture csvWriter sorted) |> Ok
     }
     
     member _.Handle(cmd:BuyOrSell) = task {
@@ -321,12 +315,12 @@ type StockPositionHandler(accounts:IAccountStorage,brokerage:IBrokerage,csvWrite
         let! user = accounts.GetUser(userId)
         
         match user with
-        | None -> return "User not found" |> ResponseUtils.failed
+        | None -> return "User not found" |> ServiceError |> Error
         | _ ->
             let! stock = storage.GetStockPosition data.PositionId userId
             
             match stock with
-            | None -> return "Stock position not found" |> ResponseUtils.failed
+            | None -> return "Stock position not found" |> ServiceError |> Error
             | Some position ->
                 
                 do!
@@ -334,14 +328,14 @@ type StockPositionHandler(accounts:IAccountStorage,brokerage:IBrokerage,csvWrite
                     |> buyOrSellFunction
                     |> storage.SaveStockPosition userId stock
                 
-                return Ok
+                return Ok ()
     }
     
     member this.Handle (cmd:ImportStocks) = task {
         let records = csvParser.Parse<ImportRecord>(cmd.Content)
-        match records.Success with
-        | None -> return records |> ResponseUtils.toOkOrError
-        | Some records ->
+        match records with
+        | Error error -> return Error error
+        | Ok records ->
             let! results =
                 records
                 |> Seq.map (fun r -> async {
@@ -377,7 +371,7 @@ type StockPositionHandler(accounts:IAccountStorage,brokerage:IBrokerage,csvWrite
     member _.Handle(userId:UserId, cmd:OpenStockPosition) = task {
         let! user = userId |> accounts.GetUser
         match user with
-        | None -> return "User not found" |> ResponseUtils.failedTyped<StockPositionWithCalculations>
+        | None -> return "User not found" |> ServiceError |> Error
         | Some _ ->
             let! stocks = storage.GetStockPositions userId
             
@@ -386,7 +380,7 @@ type StockPositionHandler(accounts:IAccountStorage,brokerage:IBrokerage,csvWrite
             
             match openPosition with
             | Some _ ->
-                return "Position already open" |> ResponseUtils.failedTyped<StockPositionWithCalculations>
+                return "Position already open" |> ServiceError |> Error
             | None ->
                 
                 let! pendingPositions = storage.GetPendingStockPositions userId
@@ -442,77 +436,73 @@ type StockPositionHandler(accounts:IAccountStorage,brokerage:IBrokerage,csvWrite
                 | None ->
                     ()
                 
-                return withCalculations |> ResponseUtils.success
+                return withCalculations |> Ok
     }
 
     member this.Handle (command:DeletePosition) = task {
         let! user = accounts.GetUser(command.UserId)
         match user with
-        | None -> return "User not found" |> ResponseUtils.failed
+        | None -> return "User not found" |> ServiceError |> Error
         | _ ->
             let! position = storage.GetStockPosition command.PositionId command.UserId
             
             match position with
-            | None -> return "Stock position not found" |> ResponseUtils.failed
+            | None -> return "Stock position not found" |> ServiceError |> Error
             | Some position ->
                 let deletedPosition = position |> StockPosition.delete 
                 do! deletedPosition |> storage.DeleteStockPosition command.UserId (Some position)
-                return Ok
+                return Ok ()
     }
     
     member this.Handle (command:ClosePosition) = task {
         let! user = accounts.GetUser(command.UserId)
         match user with
-        | None -> return "User not found" |> ResponseUtils.failed
+        | None -> return "User not found" |> ServiceError |> Error
         | Some user ->
             let! position = storage.GetStockPosition command.PositionId command.UserId
             match position with
-            | None -> return "Stock position not found" |> ResponseUtils.failed
+            | None -> return "Stock position not found" |> ServiceError |> Error
             | Some position ->
                 
                 // if short, we need to buy to cover
                 // if long, we need to sell
-                let taskToRun =
+                return!
                     match position.StockPositionType with
                     | Short -> brokerage.BuyToCoverOrder user.State position.Ticker (position.NumberOfShares |> abs) 0m BrokerageOrderType.Market BrokerageOrderDuration.Day
                     | Long -> brokerage.SellOrder user.State position.Ticker position.NumberOfShares 0m BrokerageOrderType.Market BrokerageOrderDuration.Day
-                
-                let! orderResponse = taskToRun
-                
-                return orderResponse |> ResponseUtils.toOkOrError
     }
     
     member _.Handle (userId:UserId, command:DeleteStop) = task {
         let! user = accounts.GetUser(userId)
         match user with
-        | None -> return "User not found" |> ResponseUtils.failed
+        | None -> return "User not found" |> ServiceError |> Error
         | _ ->
             let! stock = storage.GetStockPosition command.PositionId userId
             match stock with
-            | None -> return "Stock position not found" |> ResponseUtils.failed
+            | None -> return "Stock position not found" |> ServiceError |> Error
             | Some existing ->
                 do!
                     existing
                     |> StockPosition.deleteStop DateTimeOffset.UtcNow
                     |> storage.SaveStockPosition userId stock
-                return Ok
+                return Ok ()
     }
     
     member _.Handle (cmd:DeleteTransaction) = task {
         let! user = accounts.GetUser(cmd.UserId)
         match user with
-        | None -> return "User not found" |> ResponseUtils.failed
+        | None -> return "User not found" |> ServiceError |> Error
         | _ ->
             let! stock = storage.GetStockPosition cmd.PositionId cmd.UserId
             match stock with
-            | None -> return "Stock position not found" |> ResponseUtils.failed
+            | None -> return "Stock position not found" |> ServiceError |> Error
             | Some existing ->
                 do!
                     existing
                     |> StockPosition.deleteTransaction cmd.TransactionId DateTimeOffset.UtcNow
                     |> storage.SaveStockPosition cmd.UserId stock
                     
-                return Ok
+                return Ok ()
     }
         
     member this.Handle (query:Query) = task {
@@ -536,36 +526,36 @@ type StockPositionHandler(accounts:IAccountStorage,brokerage:IBrokerage,csvWrite
                 OpenCryptoCount = cryptos |> Seq.length
             }
             
-        return view |> ResponseUtils.success    
+        return view |> Ok 
     }
     
     member _.HandleGradePosition userId (command:GradePosition) = task {
         let! user = accounts.GetUser userId
         match user with
-        | None -> return "User not found" |> ResponseUtils.failed
+        | None -> return "User not found" |> ServiceError |> Error
         | _ ->
             let! stock = storage.GetStockPosition command.PositionId userId
                 
             match stock with
-            | None -> return "Stock position not found" |> ResponseUtils.failed
+            | None -> return "Stock position not found" |> ServiceError |> Error
             | Some stock ->
                 
                 do! stock
                     |> StockPosition.assignGrade command.Grade command.GradeNote DateTimeOffset.UtcNow
                     |> storage.SaveStockPosition userId (Some stock)
                 
-                return Ok
+                return Ok ()
     }
     
     member _.Handle (command:RemoveLabel) = task {
         let! user = accounts.GetUser(command.UserId)
         match user with
-        | None -> return "User not found" |> ResponseUtils.failed
+        | None -> return "User not found" |> ServiceError |> Error
         | _ ->
             let! stock = storage.GetStockPosition command.PositionId command.UserId
             
             match stock with
-            | None -> return "Stock not found" |> ResponseUtils.failed
+            | None -> return "Stock not found" |> ServiceError |> Error
             | Some stock ->
                 
                 do!
@@ -573,36 +563,36 @@ type StockPositionHandler(accounts:IAccountStorage,brokerage:IBrokerage,csvWrite
                     |> StockPosition.deleteLabel command.Key DateTimeOffset.UtcNow
                     |> storage.SaveStockPosition command.UserId (Some stock)
                 
-                return Ok
+                return Ok ()
     }
     
     member _.HandleAddLabel userId (command:AddLabel) = task {
         let! user = accounts.GetUser userId
         match user with
-        | None -> return "User not found" |> ResponseUtils.failed
+        | None -> return "User not found" |> ServiceError |> Error
         | _ ->
             let! stock = storage.GetStockPosition command.PositionId userId
             
             match stock with
-            | None -> return "Stock position not found" |> ResponseUtils.failed
+            | None -> return "Stock position not found" |> ServiceError |> Error
             | Some stock ->
                 
                 do! stock
                     |> StockPosition.setLabel command.Key command.Value DateTimeOffset.UtcNow
                     |> storage.SaveStockPosition userId (Some stock)
                 
-                return Ok
+                return Ok ()
     }
     
     member _.Handle (query:ProfitPointsQuery) = task {
         let! user = accounts.GetUser(query.UserId)
         match user with
-        | None -> return "User not found" |> ResponseUtils.failedTyped<ProfitPoints.ProfitPointContainer []>
+        | None -> return "User not found" |> ServiceError |> Error
         | _ ->
             let! stock = storage.GetStockPosition query.PositionId query.UserId 
             
             match stock with
-            | None -> return "Stock position not found" |> ResponseUtils.failedTyped<ProfitPoints.ProfitPointContainer []>
+            | None -> return "Stock position not found" |> ServiceError |> Error
             | Some stock ->
                 
                 let stock = stock |> StockPositionWithCalculations
@@ -617,23 +607,21 @@ type StockPositionHandler(accounts:IAccountStorage,brokerage:IBrokerage,csvWrite
                     
                 let percentBased = ProfitPoints.getProfitPoints percentBased query.NumberOfPoints
                     
-                let arr =
+                return 
                     [|
                         ProfitPoints.ProfitPointContainer("Stop based", prices=stopBased)
                         ProfitPoints.ProfitPointContainer($"{TradingStrategyConstants.AvgPercentGain}%% intervals", prices=percentBased)
-                    |]
-                
-                return ServiceResponse<ProfitPoints.ProfitPointContainer []>(arr)
+                    |] |> Ok
     }
     
     member _.HandleSetRisk userId (command:SetRisk) = task {
         let! user = accounts.GetUser userId
         match user with
-        | None -> return "User not found" |> ResponseUtils.failed
+        | None -> return "User not found" |> ServiceError |> Error
         | _ ->
             let! stock = storage.GetStockPosition command.PositionId userId
             match stock with
-            | None -> return "Stock not found" |> ResponseUtils.failed
+            | None -> return "Stock not found" |> ServiceError |> Error
             | Some stock ->
                 
                 do!
@@ -641,27 +629,27 @@ type StockPositionHandler(accounts:IAccountStorage,brokerage:IBrokerage,csvWrite
                     |> StockPosition.setRiskAmount command.RiskAmount.Value DateTimeOffset.UtcNow
                     |> storage.SaveStockPosition userId (Some stock)
                 
-                return Ok
+                return Ok ()
     }
     
     member _.Handle (command:SimulateTrade) = task {
         let! user = accounts.GetUser(command.UserId)
         match user with
-        | None -> return "User not found" |> ResponseUtils.failedTyped<TradingStrategyResults>
+        | None -> return "User not found" |> ServiceError |> Error
         | Some user ->
             let! stock = storage.GetStockPosition command.PositionId command.UserId
             match stock with
-            | None -> return "Stock position not found" |> ResponseUtils.failedTyped<TradingStrategyResults>
+            | None -> return "Stock position not found" |> ServiceError |> Error
             | Some stock ->
                 let runner = TradingStrategyRunner(brokerage, marketHours)
                 let! simulation = runner.Run(user.State, position=stock, closeIfOpenAtTheEnd=false)
-                return ServiceResponse<TradingStrategyResults>(simulation)
+                return simulation |> Ok
     }
     
     member _.Handle (command:SimulateTradeForTicker) = task {
         let! user = accounts.GetUser(command.UserId)
         match user with
-        | None -> return "User not found" |> ResponseUtils.failedTyped<TradingStrategyResults>
+        | None -> return "User not found" |> ServiceError |> Error
         | Some user ->
             let runner = TradingStrategyRunner(brokerage, marketHours)
                 
@@ -675,7 +663,7 @@ type StockPositionHandler(accounts:IAccountStorage,brokerage:IBrokerage,csvWrite
                     closeIfOpenAtTheEnd=false
                 )
                 
-            return ServiceResponse<TradingStrategyResults>(results)
+            return results |> Ok
     }
     
     member _.Handle (command:SimulateUserTrades) = task {
@@ -720,7 +708,7 @@ type StockPositionHandler(accounts:IAccountStorage,brokerage:IBrokerage,csvWrite
         
         let! user = accounts.GetUser(command.UserId)
         match user with
-        | None -> return "User not found" |> ResponseUtils.failedTyped<TradingStrategyPerformance array>
+        | None -> return "User not found" |> ServiceError |> Error
         | Some user ->
             
             let! stocks = storage.GetStockPositions command.UserId
@@ -740,14 +728,13 @@ type StockPositionHandler(accounts:IAccountStorage,brokerage:IBrokerage,csvWrite
                 |> Async.Sequential
                 |> Async.StartAsTask
                 
-            let results =
+            return
                 simulations
                 |> Seq.concat
                 |> Seq.groupBy (_.StrategyName)
                 |> Seq.map mapToStrategyPerformance
                 |> Seq.toArray
-                
-            return ServiceResponse<TradingStrategyPerformance array>(results)
+                |> Ok
     }
     
     member this.HandleExport (command:ExportUserSimulatedTrades) = task {
@@ -756,20 +743,20 @@ type StockPositionHandler(accounts:IAccountStorage,brokerage:IBrokerage,csvWrite
             NumberOfTrades = command.NumberOfTrades
             ClosePositionIfOpenAtTheEnd = command.ClosePositionIfOpenAtTheEnd}
         let! results = this.Handle(simulateCommand)
-        match results.IsOk with
-        | true ->
-            let content = CSVExport.strategyPerformance csvWriter results.Success.Value
-            let filename = CSVExport.generateFilename $"simulated-trades-{command.NumberOfTrades}"
-            let response = ExportResponse(filename, content);
-            return ServiceResponse<ExportResponse>(response);
-            
-        | false -> return results.Error.Value.Message |> ResponseUtils.failedTyped<ExportResponse>
+        
+        return
+            results
+            |> Result.map(fun results ->
+                let content = CSVExport.strategyPerformance csvWriter results
+                let filename = CSVExport.generateFilename $"simulated-trades-{command.NumberOfTrades}"
+                ExportResponse(filename, content)
+            ) 
     }
     
     member _.Handle (query:QueryTradingEntries) = task {
         let! user = accounts.GetUser(query.UserId)
         match user with
-        | None -> return "User not found" |> ResponseUtils.failedTyped<TradingEntriesView>
+        | None -> return "User not found" |> ServiceError |> Error
         | Some user ->
             let! stocks = storage.GetStockPositions query.UserId
             
@@ -781,9 +768,9 @@ type StockPositionHandler(accounts:IAccountStorage,brokerage:IBrokerage,csvWrite
                 
             let! accountResponse = brokerage.GetAccount(user.State)
             let account =
-                match accountResponse.Success with
-                | Some acc -> acc
-                | None -> BrokerageAccount.Empty
+                match accountResponse with
+                | Ok acc -> acc
+                | Error _ -> BrokerageAccount.Empty
                 
             let tickers =
                 positions
@@ -793,9 +780,9 @@ type StockPositionHandler(accounts:IAccountStorage,brokerage:IBrokerage,csvWrite
                 
             let! pricesResponse = brokerage.GetQuotes user.State tickers
             let prices =
-                match pricesResponse.Success with
-                | Some prices -> prices
-                | None -> Dictionary<Ticker, StockQuote>()
+                match pricesResponse with
+                | Ok prices -> prices
+                | Error _ -> Dictionary<Ticker, StockQuote>()
                 
             let pricesWithStringAsKey = prices.Keys |> Seq.map (fun p -> p.Value, prices[p]) |> Map.ofSeq
             
@@ -810,13 +797,13 @@ type StockPositionHandler(accounts:IAccountStorage,brokerage:IBrokerage,csvWrite
                     brokerageAccount=account
                     prices=pricesWithStringAsKey
                 }
-            return ServiceResponse<TradingEntriesView>(tradingEntries)
+            return tradingEntries |> Ok
     }
     
     member _.Handle (query:QueryPastTradingEntries) = task {
         let! user = accounts.GetUser(query.UserId)
         match user with
-        | None -> return "User not found" |> ResponseUtils.failedTyped<PastTradingEntriesView>
+        | None -> return "User not found" |> ServiceError |> Error
         | _ ->
             
             let! stocks = storage.GetStockPositions query.UserId
@@ -833,13 +820,13 @@ type StockPositionHandler(accounts:IAccountStorage,brokerage:IBrokerage,csvWrite
                     past=past;
                 }
                 
-            return ServiceResponse<PastTradingEntriesView>(tradingEntries)
+            return tradingEntries |> Ok
     }
     
     member _.Handle (query:QueryPastTradingPerformance) = task {
         let! user = accounts.GetUser(query.UserId)
         match user with
-        | None -> return "User not found" |> ResponseUtils.failedTyped<PastTradingPerformanceView>
+        | None -> return "User not found" |> ServiceError |> Error
         | _ ->
             
             let! stocks = storage.GetStockPositions query.UserId
@@ -870,7 +857,7 @@ type StockPositionHandler(accounts:IAccountStorage,brokerage:IBrokerage,csvWrite
                     strategyPerformance=strategyByPerformance;
                 }
                 
-            return ServiceResponse<PastTradingPerformanceView>(tradingEntries)
+            return tradingEntries |> Ok
     }
     
     member _.Handle(query:QueryTransactions) = task {
@@ -916,9 +903,9 @@ type StockPositionHandler(accounts:IAccountStorage,brokerage:IBrokerage,csvWrite
         let! options = storage.GetOwnedOptions(query.UserId)
         let! cryptos = storage.GetCryptos(query.UserId)
         
-        let transactionsView = toTransactionsView (stocks |> Seq.map StockPositionWithCalculations) options cryptos
+        let transactionsView = toTransactionsView (stocks |> Seq.map StockPositionWithCalculations) options cryptos 
         
-        return ServiceResponse<TransactionsView>(transactionsView)
+        return transactionsView |> Ok
     }
     
     member _.Handle (query:TransactionSummary) = task {
@@ -973,18 +960,18 @@ type StockPositionHandler(accounts:IAccountStorage,brokerage:IBrokerage,csvWrite
             plOptionTransactions=plOptionTransactions
         )
         
-        return ServiceResponse<TransactionSummaryView>(view)
+        return view
     }
     
     member _.HandleStop(userId,cmd:SetStop) = task {
         let! stock = storage.GetStockPosition cmd.PositionId userId
         match stock with
-        | None -> return "Stock position not found" |> ResponseUtils.failed
+        | None -> return "Stock position not found" |> ServiceError |> Error
         | Some existing ->
             do!
                 existing
                 |> StockPosition.setStop cmd.StopPrice DateTimeOffset.UtcNow
                 |> storage.SaveStockPosition userId stock
                 
-            return Ok
+            return Ok ()
     }

--- a/src/core.fs/Routines/Handler.fs
+++ b/src/core.fs/Routines/Handler.fs
@@ -80,119 +80,119 @@ type Handler(accounts:IAccountStorage,storage:IPortfolioStorage) =
         
         let! user = accounts.GetUser userId
         match user with
-        | None -> return "User not found" |> ResponseUtils.failedTyped<RoutineState>
+        | None -> return "User not found" |> ServiceError |> Error
         | Some _ ->
             let! routine = storage.GetRoutine create.Name userId
             match routine with
             | null ->
                 let routine = Routine(name=create.Name,description=create.Description,userId=(userId |> IdentifierHelper.getUserId))
                 do! storage.SaveRoutine routine userId
-                return ServiceResponse<RoutineState>(routine.State)
-            | _ -> return "Routine already exists" |> ResponseUtils.failedTyped<RoutineState>
+                return routine.State |> Ok
+            | _ -> return "Routine already exists" |> ServiceError |> Error
     }
     
     member _.HandleUpdate userId (update:Update) = task {
         
         let! user = accounts.GetUser userId
         match user with
-        | None -> return "User not found" |> ResponseUtils.failedTyped<RoutineState>
+        | None -> return "User not found" |> ServiceError |> Error
         | _ ->
             let! routine = storage.GetRoutine update.Name userId
             match routine with
-            | null -> return "Routine not found" |> ResponseUtils.failedTyped<RoutineState>
+            | null -> return "Routine not found" |> ServiceError |> Error
             | _ ->
                 routine.Update(name=update.NewName,description=update.Description)
                 do! storage.SaveRoutine routine userId
-                return ServiceResponse<RoutineState>(routine.State)
+                return routine.State |> Ok
     }
     
     member _.Handle (delete:Delete) = task {
         
         let! user = accounts.GetUser delete.UserId
         match user with
-        | None -> return "User not found" |> ResponseUtils.failedTyped<RoutineState>
+        | None -> return "User not found" |> ServiceError |> Error
         | _ ->
             let! routine = storage.GetRoutine delete.Name delete.UserId
             match routine with
-            | null -> return "Routine not found" |> ResponseUtils.failedTyped<RoutineState>
+            | null -> return "Routine not found" |> ServiceError |> Error
             | _ ->
                 do! storage.DeleteRoutine routine delete.UserId
-                return ServiceResponse<RoutineState>(routine.State)
+                return routine.State |> Ok
     }
     
     member _.Handle (query:Query) = task {
         
         let! user = accounts.GetUser query.UserId
         match user with
-        | None -> return "User not found" |> ResponseUtils.failedTyped<RoutineState array>
+        | None -> return "User not found" |> ServiceError |> Error
         | _ ->
             let! routines = storage.GetRoutines query.UserId
-            let states =
+            return
                 routines
-                |> Seq.map (fun routine -> routine.State)
-                |> Seq.sortBy (fun state -> state.Name.ToLower())
+                |> Seq.map (_.State)
+                |> Seq.sortBy (_.Name.ToLower())
                 |> Seq.toArray
-            return ServiceResponse<RoutineState array>(states)
+                |> Ok
     }
     
     member _.HandleAddStep userId (add:AddStep) = task {
         
         let! user = accounts.GetUser userId
         match user with
-        | None -> return "User not found" |> ResponseUtils.failedTyped<RoutineState>
+        | None -> return "User not found" |> ServiceError |> Error
         | _ ->
             let! routine = storage.GetRoutine add.RoutineName userId
             match routine with
-            | null -> return "Routine not found" |> ResponseUtils.failedTyped<RoutineState>
+            | null -> return "Routine not found" |> ServiceError |> Error
             | _ ->
                 routine.AddStep(label=add.Label,url=add.Url)
                 do! storage.SaveRoutine routine userId
-                return ServiceResponse<RoutineState>(routine.State)
+                return routine.State |> Ok
     }
     
     member _.HandleMoveStep userId (move:MoveStep) = task {
         
         let! user = accounts.GetUser userId
         match user with
-        | None -> return "User not found" |> ResponseUtils.failedTyped<RoutineState>
+        | None -> return "User not found" |> ServiceError |> Error
         | _ ->
             let! routine = storage.GetRoutine move.RoutineName userId
             match routine with
-            | null -> return "Routine not found" |> ResponseUtils.failedTyped<RoutineState>
+            | null -> return "Routine not found" |> ServiceError |> Error
             | _ ->
                 routine.MoveStep(stepIndex=move.StepIndex.Value,direction=move.Direction.Value)
                 do! storage.SaveRoutine routine userId
-                return ServiceResponse<RoutineState>(routine.State)
+                return routine.State |> Ok
     }
     
     member _.Handle (remove:RemoveStep) = task {
         
         let! user = accounts.GetUser remove.UserId
         match user with
-        | None -> return "User not found" |> ResponseUtils.failedTyped<RoutineState>
+        | None -> return "User not found" |> ServiceError |> Error
         | _ ->
             let! routine = storage.GetRoutine remove.RoutineName remove.UserId
             match routine with
-            | null -> return "Routine not found" |> ResponseUtils.failedTyped<RoutineState>
+            | null -> return "Routine not found" |> ServiceError |> Error
             | _ ->
                 routine.RemoveStep(index=remove.StepIndex.Value)
                 do! storage.SaveRoutine routine remove.UserId
-                return ServiceResponse<RoutineState>(routine.State)
+                return routine.State |> Ok
     }
     
     member _.HandleUpdateStep userId (update:UpdateStep) = task {
         
         let! user = accounts.GetUser userId
         match user with
-        | None -> return "User not found" |> ResponseUtils.failedTyped<RoutineState>
+        | None -> return "User not found" |> ServiceError |> Error
         | _ ->
             let! routine = storage.GetRoutine update.RoutineName userId
             match routine with
-            | null -> return "Routine not found" |> ResponseUtils.failedTyped<RoutineState>
+            | null -> return "Routine not found" |> ServiceError |> Error
             | _ ->
                 routine.UpdateStep(index=update.StepIndex.Value,label=update.Label,url=update.Url)
                 do! storage.SaveRoutine routine userId
-                return ServiceResponse<RoutineState>(routine.State)
+                return routine.State |> Ok
     }
     
     

--- a/src/core.fs/Services/TradeSimulations.fs
+++ b/src/core.fs/Services/TradeSimulations.fs
@@ -301,9 +301,9 @@ type TradingStrategyRunner(brokerage:IBrokerageGetPriceHistory, hours:IMarketHou
                     
             let results = TradingStrategyResults()
             
-            match prices.Success with
-            | None -> results.MarkAsFailed($"Failed to get price history for {ticker}: {prices.Error.Value.Message}")
-            | Some bars ->
+            match prices with
+            | Error err -> results.MarkAsFailed($"Failed to get price history for {ticker}: {err.Message}")
+            | Ok bars ->
                 match bars.Bars with
                 | [||] -> results.MarkAsFailed($"No price history found for {ticker}")
                 | _ ->

--- a/src/core.fs/Stocks/ListsHandler.fs
+++ b/src/core.fs/Stocks/ListsHandler.fs
@@ -96,156 +96,156 @@ type Handler(accounts:IAccountStorage, portfolio:IPortfolioStorage, csvWriter:IC
         let! user = accounts.GetUser(command.UserId)
         
         match user with
-        | None -> return "User not found" |> ResponseUtils.failedTyped<StockListState array>
+        | None -> return "User not found" |> ServiceError |> Error
         | _ ->
             let! lists = portfolio.GetStockLists(command.UserId)
-            let states = lists |> Seq.map (fun l -> l.State) |> Seq.sortBy (fun s -> s.Name) |> Seq.toArray
-            return states |> ResponseUtils.success
+            let states = lists |> Seq.map _.State |> Seq.sortBy _.Name |> Seq.toArray
+            return states |> Ok
     }
     
     member _.Handle (command: GetList) = task {
         let! user = accounts.GetUser(command.UserId)
         
         match user with
-        | None -> return "User not found" |> ResponseUtils.failedTyped<StockListState>
+        | None -> return "User not found"  |> ServiceError |> Error
         | _ ->
             let! list = portfolio.GetStockList command.Name command.UserId
             match list with
-            | null -> return "List not found" |> ResponseUtils.failedTyped<StockListState>
-            | _ -> return list.State |> ResponseUtils.success
+            | null -> return "List not found" |> ServiceError |> Error
+            | _ -> return list.State |> Ok
     }
     
     member _.Handle (command: ExportList) = task {
         let! user = accounts.GetUser(command.UserId)
         
         match user with
-        | None -> return "User not found" |> ResponseUtils.failedTyped<ExportResponse>
+        | None -> return "User not found" |> ServiceError |> Error
         | _ ->
             let! list = portfolio.GetStockList command.Name command.UserId
             match list with
-            | null -> return "List not found" |> ResponseUtils.failedTyped<ExportResponse>
+            | null -> return "List not found" |> ServiceError |> Error
             | _ ->
                 let filename = CSVExport.generateFilename($"Stocks_{command.Name}");
                 let response = ExportResponse(filename, CSVExport.stockList csvWriter list.State command.JustTickers)
-                return response |> ResponseUtils.success
+                return response |> Ok
     }
     
     member _.HandleAddStockToList userId (command: AddStockToList) = task {
         let! user = accounts.GetUser userId
         
         match user with
-        | None -> return "User not found" |> ResponseUtils.failedTyped<StockListState>
+        | None -> return "User not found" |> ServiceError |> Error
         | _ ->
             let! list = portfolio.GetStockList command.Name userId
             match list with
-            | null -> return "List not found" |> ResponseUtils.failedTyped<StockListState>
+            | null -> return "List not found" |> ServiceError |> Error
             | _ ->
                 list.AddStock(ticker=command.Ticker, note=null)
                 do! portfolio.SaveStockList list userId
-                return list.State |> ResponseUtils.success
+                return list.State |> Ok
     }
     
     member _.Handle (command: RemoveStockFromList) = task {
         let! user = accounts.GetUser(command.UserId)
         
         match user with
-        | None -> return "User not found" |> ResponseUtils.failedTyped<StockListState>
+        | None -> return "User not found" |> ServiceError |> Error
         | _ ->
             let! list = portfolio.GetStockList command.Name command.UserId
             match list with
-            | null -> return "List not found" |> ResponseUtils.failedTyped<StockListState>
+            | null -> return "List not found" |> ServiceError |> Error
             | _ ->
                 list.RemoveStock(ticker=command.Ticker)
                 do! portfolio.SaveStockList list command.UserId
-                return list.State |> ResponseUtils.success
+                return list.State |> Ok
     }
     
     member _.HandleAddTagToList userId (command: AddTagToList) = task {
         let! user = accounts.GetUser userId
         
         match user with
-        | None -> return "User not found" |> ResponseUtils.failedTyped<StockListState>
+        | None -> return "User not found" |> ServiceError |> Error
         | _ ->
             let! list = portfolio.GetStockList command.Name userId
             match list with
-            | null -> return "List not found" |> ResponseUtils.failedTyped<StockListState>
+            | null -> return "List not found" |> ServiceError |> Error
             | _ ->
                 list.AddTag(tag=command.Tag)
                 do! portfolio.SaveStockList list userId
-                return list.State |> ResponseUtils.success
+                return list.State |> Ok
     }
     
     member _.Handle (command: RemoveTagFromList) = task {
         let! user = accounts.GetUser(command.UserId)
         
         match user with
-        | None -> return "User not found" |> ResponseUtils.failedTyped<StockListState>
+        | None -> return "User not found" |> ServiceError |> Error
         | _ ->
             let! list = portfolio.GetStockList command.Name command.UserId
             match list with
-            | null -> return "List not found" |> ResponseUtils.failedTyped<StockListState>
+            | null -> return "List not found" |> ServiceError |> Error
             | _ ->
                 list.RemoveTag(tag=command.Tag)
                 do! portfolio.SaveStockList list command.UserId
-                return list.State |> ResponseUtils.success
+                return list.State |> Ok
     }
     
     member _.HandleCreate userId (command: Create) = task {
         let! user = accounts.GetUser userId
         
         match user with
-        | None -> return "User not found" |> ResponseUtils.failedTyped<StockListState>
+        | None -> return "User not found" |> ServiceError |> Error
         | _ ->
             let! list = portfolio.GetStockList command.Name userId
             match list with
             | null ->
                 let newList = StockList(name=command.Name, description=command.Description, userId=(userId |> IdentifierHelper.getUserId))
                 do! portfolio.SaveStockList newList userId
-                return newList.State |> ResponseUtils.success
+                return newList.State |> Ok
             | _ ->
-                return "List already exists" |> ResponseUtils.failedTyped<StockListState>
+                return "List already exists" |> ServiceError |> Error
     }
     
     member _.HandleUpdate userId (command: Update) = task {
         let! user = accounts.GetUser userId
         
         match user with
-        | None -> return "User not found" |> ResponseUtils.failedTyped<StockListState>
+        | None -> return "User not found" |> ServiceError |> Error
         | _ ->
             let! list = portfolio.GetStockList command.Name userId
             match list with
-            | null -> return "List not found" |> ResponseUtils.failedTyped<StockListState>
+            | null -> return "List not found" |> ServiceError |> Error
             | _ ->
                 list.Update(name=command.Name, description=command.Description)
                 do! portfolio.SaveStockList list userId
-                return list.State |> ResponseUtils.success
+                return list.State |> Ok
     }
     
     member _.Handle (command: Delete) = task {
         let! user = accounts.GetUser(command.UserId)
         
         match user with
-        | None -> return "User not found" |> ResponseUtils.failed
+        | None -> return "User not found" |> ServiceError |> Error
         | _ ->
             let! list = portfolio.GetStockList command.Name command.UserId
             match list with
-            | null -> return "List not found" |> ResponseUtils.failed
+            | null -> return "List not found" |> ServiceError |> Error
             | _ ->
                 do! portfolio.DeleteStockList list command.UserId
-                return Ok
+                return Ok ()
     }
     
     member _.Handle (clear:Clear) = task {
         let! user = accounts.GetUser(clear.UserId)
         
         match user with
-        | None -> return "User not found" |> ResponseUtils.failed
+        | None -> return "User not found" |> ServiceError |> Error
         | _ ->
             let! list = portfolio.GetStockList clear.Name clear.UserId
             match list with
-            | null -> return "List not found" |> ResponseUtils.failed
+            | null -> return "List not found" |> ServiceError |> Error
             | _ ->
                 list.Clear()
                 do! portfolio.SaveStockList list clear.UserId
-                return Ok
+                return Ok ()
     }

--- a/src/infrastructure/csvparser/CSVParser.cs
+++ b/src/infrastructure/csvparser/CSVParser.cs
@@ -8,12 +8,13 @@ using core.fs;
 using core.fs.Adapters.CSV;
 using CsvHelper;
 using CsvHelper.Configuration;
+using Microsoft.FSharp.Core;
 
 namespace csvparser
 {
     public class CSVParser : ICSVParser
     {
-        public ServiceResponse<IEnumerable<T>> Parse<T>(string content)
+        public FSharpResult<IEnumerable<T>,ServiceError> Parse<T>(string content)
         {
             try
             {
@@ -36,12 +37,12 @@ namespace csvparser
 
                 var records = csvReader.GetRecords<T>().ToList(); // doing to list to make sure that the file is read
                 // before reader gets disposed
-                return new ServiceResponse<IEnumerable<T>>(records);
+                return FSharpResult<IEnumerable<T>, ServiceError>.NewOk(records);
             }
             catch(HeaderValidationException ex)
             {
                 var error = "Header validation failed: " + ex.Message;
-                return new ServiceResponse<IEnumerable<T>>(new ServiceError(error));
+                return FSharpResult<IEnumerable<T>, ServiceError>.NewError(new ServiceError(error));
             }
         }
     }

--- a/src/infrastructure/secedgar/EdgarClient.cs
+++ b/src/infrastructure/secedgar/EdgarClient.cs
@@ -2,6 +2,7 @@
 using core.fs.Adapters.SEC;
 using core.Shared;
 using Microsoft.Extensions.Logging;
+using Microsoft.FSharp.Core;
 using SecuritiesExchangeCommission.Edgar;
 
 namespace secedgar;
@@ -19,7 +20,7 @@ public class EdgarClient : ISECFilings
     }
         
 
-    public async Task<ServiceResponse<CompanyFilings>> GetFilings(Ticker symbol)
+    public async Task<FSharpResult<CompanyFilings,ServiceError>> GetFilings(Ticker symbol)
     {
         try
         {
@@ -44,13 +45,13 @@ public class EdgarClient : ISECFilings
 
             var result = new CompanyFilings(symbol, filings);
 
-            return new ServiceResponse<CompanyFilings>(result);
+            return FSharpResult<CompanyFilings, ServiceError>.NewOk(result);
         }
         catch (Exception ex)
         {
             _logger?.LogError(ex, "Error getting SEC filings for {symbol}", symbol);
 
-            return new ServiceResponse<CompanyFilings>(
+            return FSharpResult<CompanyFilings, ServiceError>.NewError(
                 new ServiceError(ex.Message)
             );
         }

--- a/src/infrastructure/storage.shared/IOutbox.cs
+++ b/src/infrastructure/storage.shared/IOutbox.cs
@@ -4,11 +4,12 @@ using System.Data;
 using System.Threading.Tasks;
 using core.fs;
 using core.Shared;
+using Microsoft.FSharp.Core;
 
 namespace storage.shared
 {
     public interface IOutbox
     {
-        Task<ServiceResponse> AddEvents(List<AggregateEvent> e, IDbTransaction? tx);
+        Task<FSharpResult<Unit,ServiceError>> AddEvents(List<AggregateEvent> e, IDbTransaction? tx);
     }
 }

--- a/src/infrastructure/tdameritradeclient/TDAmeritradeClient.cs
+++ b/src/infrastructure/tdameritradeclient/TDAmeritradeClient.cs
@@ -99,7 +99,7 @@ public class TDAmeritradeClient : IBrokerage
         return Task.FromResult(url);
     }
 
-    public async Task<ServiceResponse<StockProfile>> GetStockProfile(UserState state, Ticker ticker)
+    public async Task<FSharpResult<StockProfile,ServiceError>> GetStockProfile(UserState state, Ticker ticker)
     {
         if (state.ConnectedToBrokerage == false)
         {
@@ -478,12 +478,12 @@ public class TDAmeritradeClient : IBrokerage
         };
     }
 
-    private static ServiceResponse<T> NotConnectedToBrokerageError<T>()
+    private static FSharpResult<T,ServiceError> NotConnectedToBrokerageError<T>()
     {
-        return new ServiceResponse<T>(new ServiceError("User is not connected to brokerage"));
+        return FSharpResult<T,ServiceError>.NewError(new ServiceError("User is not connected to brokerage"));
     }
 
-    public async Task<ServiceResponse<core.fs.Adapters.Options.OptionChain>> GetOptions(UserState state, Ticker ticker, FSharpOption<DateTimeOffset> expirationDate, FSharpOption<decimal> strikePrice, FSharpOption<string> contractType)
+    public async Task<FSharpResult<core.fs.Adapters.Options.OptionChain, ServiceError>> GetOptions(UserState state, Ticker ticker, FSharpOption<DateTimeOffset> expirationDate, FSharpOption<decimal> strikePrice, FSharpOption<string> contractType)
     {
         if (state.ConnectedToBrokerage == false)
         {
@@ -512,7 +512,7 @@ public class TDAmeritradeClient : IBrokerage
 
         if (chainResponse.IsOk == false)
         {
-            return new ServiceResponse<core.fs.Adapters.Options.OptionChain>(chainResponse.Error.Value);
+            return FSharpResult<core.fs.Adapters.Options.OptionChain,ServiceError>.NewError(chainResponse.Error.Value);
         }
 
         static IEnumerable<core.fs.Adapters.Options.OptionDetail> ToOptionDetails(Dictionary<string, OptionDescriptorMap> map, decimal? underlyingPrice) =>
@@ -549,7 +549,7 @@ public class TDAmeritradeClient : IBrokerage
             options: ToOptionDetails(chain.callExpDateMap!, chain.underlyingPrice).Union(ToOptionDetails(chain.putExpDateMap!, chain.underlyingPrice)).ToArray()
         );
 
-        return new ServiceResponse<core.fs.Adapters.Options.OptionChain>(response);
+        return FSharpResult<core.fs.Adapters.Options.OptionChain,ServiceError>.NewOk(response);
     }
 
     public async Task<ServiceResponse<MarketHours>> GetMarketHours(UserState state, DateTimeOffset date)

--- a/src/studies/DataHelpers.fs
+++ b/src/studies/DataHelpers.fs
@@ -4,10 +4,11 @@ open System
 open System.Collections.Concurrent
 open System.Threading.Tasks
 open Microsoft.Extensions.Logging
+open core.fs
 open core.fs.Adapters.Stocks
 
 type IGetPriceHistory =
-    abstract member GetPriceHistory : start:DateTimeOffset -> ``end``:DateTimeOffset -> ticker:core.Shared.Ticker -> Task<core.fs.ServiceResponse<PriceBars>>
+    abstract member GetPriceHistory : start:DateTimeOffset -> ``end``:DateTimeOffset -> ticker:core.Shared.Ticker -> Task<Result<PriceBars,ServiceError>>
 
 type PriceAvailability =
     | Available of PriceBars
@@ -88,8 +89,7 @@ let getPricesFromBrokerageAndRecordToCsv (brokerage:IGetPriceHistory) studiesDir
     try
         callLogFuncIfSetup _.LogInformation("Getting price history for {ticker} from {startDate} to {endDate}", ticker, startDate, endDate)
         let! response = brokerage.GetPriceHistory startDate endDate ticker |> Async.AwaitTask
-        let result = response.Result
-        match result with
+        match response with
         | Ok prices ->
             recordPrices prices
             return Available prices

--- a/src/web/Controllers/AdminController.cs
+++ b/src/web/Controllers/AdminController.cs
@@ -31,12 +31,12 @@ namespace web.Controllers
         {
             var status = await handler.Handle(new LookupById(UserId.NewUserId(userId)));
 
-            if (status.IsOk == false)
+            if (status.IsError)
             {
                 return NotFound();
             }
             
-            await AccountController.EstablishSignedInIdentity(HttpContext, status.Success.Value);
+            await AccountController.EstablishSignedInIdentity(HttpContext, status.ResultValue);
 
             return Redirect("~/");
         }
@@ -80,8 +80,8 @@ namespace web.Controllers
         }
 
         [HttpGet("users/export")]
-        public Task<ActionResult> Export() => this.GenerateExport(
-            _handler.Handle(
+        public async Task<ActionResult> Export() => this.GenerateExport(
+            await _handler.Handle(
                 new Export()
             )
         );

--- a/src/web/Controllers/AlertsController.cs
+++ b/src/web/Controllers/AlertsController.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using core.fs.Alerts;
 using Microsoft.AspNetCore.Authorization;
@@ -41,9 +42,9 @@ namespace web.Controllers
         public ActionResult Run() => this.OkOrError(_handler.Handle(new Run()));
 
         [HttpGet]
-        public ActionResult Index() => this.OkOrError(_handler.Handle(new QueryAlerts(User.Identifier())));
+        public AlertsView Index() => _handler.Handle(new QueryAlerts(User.Identifier()));
 
         [HttpGet("monitors")]
-        public ActionResult Monitors() => this.OkOrError(_handler.Handle(new QueryAvailableMonitors()));
+        public IEnumerable<object> Monitors() => _handler.Handle(new QueryAvailableMonitors());
     }
 }

--- a/src/web/Controllers/OptionsController.cs
+++ b/src/web/Controllers/OptionsController.cs
@@ -101,10 +101,10 @@ namespace web.Controllers
             );
         
         [HttpGet("export")]
-        public Task<ActionResult> Export()
+        public async Task<ActionResult> Export()
         {
             return this.GenerateExport(
-                _service.Handle(
+                await _service.Handle(
                     new ExportQuery(
                         User.Identifier()
                     )

--- a/src/web/Controllers/PortfolioController.cs
+++ b/src/web/Controllers/PortfolioController.cs
@@ -38,12 +38,9 @@ public class PortfolioController : ControllerBase
         );
 
     [HttpGet("transactionsummary")]
-    public Task<ActionResult> Review(string period) =>
-        this.OkOrError(
-            _stockPositionHandler.Handle(
-                new TransactionSummary(period: period, userId: User.Identifier()
-                )
-            )
+    public Task<TransactionSummaryView> Review(string period) =>
+        _stockPositionHandler.Handle(
+            new TransactionSummary(period: period, userId: User.Identifier())
         );
 
     [HttpGet("stockpositions/export/closed")]
@@ -63,9 +60,9 @@ public class PortfolioController : ControllerBase
         );
     
     [HttpGet("stockpositions/export/transactions")]
-    public Task<ActionResult> Export() =>
+    public async Task<ActionResult> Export() =>
         this.GenerateExport(
-            _stockPositionHandler.Handle(
+            await _stockPositionHandler.Handle(
                 new ExportTransactions(User.Identifier())
             )
         );

--- a/src/web/Controllers/ReportsController.cs
+++ b/src/web/Controllers/ReportsController.cs
@@ -23,12 +23,10 @@ namespace web.Controllers
         }
         
         [HttpGet("chain")]
-        public Task<ActionResult> Chain() =>
-            this.OkOrError(
-                _service.Handle(
-                    new ChainQuery(
-                        User.Identifier()
-                    )
+        public Task<ChainView> Chain() =>
+            _service.Handle(
+                new ChainQuery(
+                    User.Identifier()
                 )
             );
 

--- a/src/web/Utils/ControllerBaseExtensions.cs
+++ b/src/web/Utils/ControllerBaseExtensions.cs
@@ -29,7 +29,7 @@ namespace web.Utils
 
                 if (response.IsError)
                 {
-                    return controller.Error(response.ErrorValue.Message);
+                    return controller.Error(response.ErrorValue);
                 }
 
                 return controller.GenerateExport(response.ResultValue);
@@ -37,11 +37,11 @@ namespace web.Utils
 
         public static ActionResult Error(
             this ControllerBase controller,
-            string error)
+            ServiceError error)
         {
             
             var dict = new Microsoft.AspNetCore.Mvc.ModelBinding.ModelStateDictionary();
-            dict.AddModelError("error", error);
+            dict.AddModelError("error", error.Message);
             return controller.BadRequest(dict);
         }
         
@@ -65,7 +65,7 @@ namespace web.Utils
         {
             if (r.IsError)
             {
-                return controller.Error(r.ErrorValue.Message);
+                return controller.Error(r.ErrorValue);
             }
 
             return controller.Ok();
@@ -77,7 +77,7 @@ namespace web.Utils
         {
             if (r.IsOk == false)
             {
-                return controller.Error(r.ErrorValue.Message);
+                return controller.Error(r.ErrorValue);
             }
 
             return controller.Ok(r.ResultValue);

--- a/src/web/Utils/CookieEvents.cs
+++ b/src/web/Utils/CookieEvents.cs
@@ -50,7 +50,7 @@ namespace web.Utils
             }
 
             identity.AddClaim(
-                new Claim(IdentityExtensions.ID_CLAIM_NAME, response.Success.Value.Id.ToString())
+                new Claim(IdentityExtensions.ID_CLAIM_NAME, response.ResultValue.Id.ToString())
             );
         }
 

--- a/src/web/Utils/MediatRBasedOutbox.cs
+++ b/src/web/Utils/MediatRBasedOutbox.cs
@@ -1,7 +1,9 @@
 using System.Collections.Generic;
 using System.Data;
 using System.Threading.Tasks;
+using core.fs;
 using core.Shared;
+using Microsoft.FSharp.Core;
 using storage.shared;
 
 namespace web.Utils;
@@ -13,7 +15,7 @@ public class IncompleteOutbox : IOutbox
     // but it was without any ability to handle failures etc and dependent on
     // mediatr. I might still use simple outbox that does not offer failure handling
     // but it will not be dependent on mediatr
-    public Task<core.fs.ServiceResponse> AddEvents(List<AggregateEvent> e, IDbTransaction tx)
+    public Task<FSharpResult<Unit,ServiceError>> AddEvents(List<AggregateEvent> e, IDbTransaction tx)
     {
         foreach (var @event in e)
         {
@@ -53,7 +55,7 @@ public class IncompleteOutbox : IOutbox
             // }
         }
 
-        return Task.FromResult(core.fs.ServiceResponse.Ok);
+        return Task.FromResult(FSharpResult<Unit, ServiceError>.NewOk(null));
     }
 }
 

--- a/tests/coretests.fs/Stocks/Services/Trading/TradingStrategyRunnerTests.fs
+++ b/tests/coretests.fs/Stocks/Services/Trading/TradingStrategyRunnerTests.fs
@@ -4,7 +4,6 @@ open System
 open System.Threading.Tasks
 open Xunit
 open core.Account
-open core.fs
 open core.fs.Adapters.Brokerage
 open core.fs.Adapters.Stocks
 open core.fs.Services.Trading
@@ -38,7 +37,7 @@ let createRunner numberOfBars priceFunction =
         {
             new IBrokerageGetPriceHistory with 
                 member this.GetPriceHistory userState ticker priceFrequency start ``end`` =
-                    prices |> ServiceResponse<PriceBars> |> Task.FromResult
+                    prices |> Ok |> Task.FromResult
         }
     
     TradingStrategyRunner(mock, MarketHoursAlwaysOn()), prices

--- a/tests/coretests/Options/DashboardTests.cs
+++ b/tests/coretests/Options/DashboardTests.cs
@@ -43,14 +43,14 @@ namespace coretests.Options
             var brokerage = new Mock<IBrokerage>();
             brokerage.Setup(x => x.GetQuotes(It.IsAny<UserState>(), It.IsAny<List<Ticker>>()))
                 .Returns(Task.FromResult(
-                    new ServiceResponse<Dictionary<Ticker, StockQuote>>(
+                    FSharpResult<Dictionary<Ticker, StockQuote>, ServiceError>.NewOk(
                         new Dictionary<Ticker, StockQuote>()
                     )
                 ));
 
             brokerage.Setup(x => x.GetAccount(It.IsAny<UserState>()))
                 .Returns(Task.FromResult(
-                    new ServiceResponse<BrokerageAccount>(
+                    FSharpResult<BrokerageAccount,ServiceError>.NewOk(
                         new BrokerageAccount {
                             OptionPositions = Array.Empty<OptionPosition>(),
                             StockPositions = Array.Empty<StockPosition>(),
@@ -62,7 +62,7 @@ namespace coretests.Options
 
             var result = await handler.Handle(query);
 
-            Assert.Equal(0, result.Success.Value.BuyStats.Count);
+            Assert.Equal(0, result.ResultValue.BuyStats.Count);
         }
     }
 }

--- a/tests/coretests/Options/DetailsTests.cs
+++ b/tests/coretests/Options/DetailsTests.cs
@@ -43,7 +43,7 @@ namespace coretests.Options
             var brokerage = new Mock<IBrokerage>();
             brokerage.Setup(x => x.GetOptions(It.IsAny<UserState>(), It.IsAny<Ticker>(), null, null, null))
                 .Returns(Task.FromResult(
-                    new ServiceResponse<OptionChain>(new OptionChain("TICKER", 0, 0, Array.Empty<OptionDetail>()))
+                    FSharpResult<OptionChain,ServiceError>.NewOk(new OptionChain("TICKER", 0, 0, Array.Empty<OptionDetail>()))
                 ));
             
             var handler = new Handler(accountMock.Object, brokerage.Object, storage, Mock.Of<ICSVWriter>());

--- a/tests/infrastructuretests/secedgartests/EdgarClientTests.cs
+++ b/tests/infrastructuretests/secedgartests/EdgarClientTests.cs
@@ -11,6 +11,6 @@ public class EdgarClientTests
     {
         var client = new EdgarClient(null, "NGTD/1.0");
         var response = await client.GetFilings(new Ticker("AAPL"));
-        Assert.NotEmpty(response.Success.Value.Filings);
+        Assert.NotEmpty(response.ResultValue.Filings);
     }
 }

--- a/tests/storagetests/FakeMediator.cs
+++ b/tests/storagetests/FakeMediator.cs
@@ -3,15 +3,14 @@ using System.Data;
 using System.Threading.Tasks;
 using core.fs;
 using core.Shared;
+using Microsoft.FSharp.Core;
 using storage.shared;
 
 namespace storagetests
 {
     public class FakeOutbox : IOutbox
     {
-        public Task<ServiceResponse> AddEvents(List<AggregateEvent> e, IDbTransaction tx)
-        {
-            return Task.FromResult(ServiceResponse.Ok);
-        }
+        public Task<FSharpResult<Unit,ServiceError>> AddEvents(List<AggregateEvent> e, IDbTransaction tx) =>
+            Task.FromResult(FSharpResult<Unit, ServiceError>.NewOk(null));
     }
 }

--- a/tests/studiestests/DataHelpersTests.fs
+++ b/tests/studiestests/DataHelpersTests.fs
@@ -17,7 +17,7 @@ let setupGetPricesWithNoBrokerageAccess =
     {
         new DataHelpers.IGetPriceHistory with 
             member this.GetPriceHistory start ``end`` ticker = task {
-                return [||] |> PriceBars |> core.fs.ServiceResponse<PriceBars>
+                return [||] |> PriceBars |> Ok
             }
     }
         
@@ -99,7 +99,7 @@ let ``Get prices with brokerage should go to brokerage if price does not exists 
                             [|PriceBar(DateTimeOffset.UtcNow, 1.0M, 1.0M, 1.0M, 1.0M, 1)|]
                             |> PriceBars
                             
-                        return bars |> core.fs.ServiceResponse<PriceBars>
+                        return bars |> Ok
                     }
         }
     
@@ -127,7 +127,7 @@ let ``Make sure error is recorded if brokerage fails``() = async {
             new DataHelpers.IGetPriceHistory with 
                 member this.GetPriceHistory start ``end`` ticker =
                     task {
-                        return core.fs.ServiceError(transactionRateErrorMessage) |> core.fs.ServiceResponse<PriceBars>
+                        return core.fs.ServiceError(transactionRateErrorMessage) |> Error
                     }
         }
         
@@ -156,7 +156,7 @@ let ``When prices are not available for perpetuity, brokerage is not pinged``() 
                 member this.GetPriceHistory start ``end`` ticker =
                     task {
                         call <- call + 1
-                        return core.fs.ServiceError("No candles for historical prices for " + ticker.Value) |> core.fs.ServiceResponse<PriceBars>
+                        return core.fs.ServiceError("No candles for historical prices for " + ticker.Value) |> Error
                     }
         }
     

--- a/tests/studiestests/PriceTransformationTests.fs
+++ b/tests/studiestests/PriceTransformationTests.fs
@@ -75,9 +75,9 @@ let ``Transform retries fetching the prices until all the price feeds are availa
                         return
                             match callCount with
                             | x when x >= 2 ->
-                                TestDataGenerator.PriceBars(TestDataGenerator.NET) |> core.fs.ServiceResponse<core.fs.Adapters.Stocks.PriceBars>
+                                TestDataGenerator.PriceBars(TestDataGenerator.NET) |> Ok
                             | _ ->
-                                core.fs.ServiceError(DataHelpersTests.transactionRateErrorMessage) |> core.fs.ServiceResponse<core.fs.Adapters.Stocks.PriceBars>
+                                core.fs.ServiceError(DataHelpersTests.transactionRateErrorMessage) |> Error
                     }
         }
         

--- a/tests/studiestests/TradingTests.fs
+++ b/tests/studiestests/TradingTests.fs
@@ -262,7 +262,7 @@ let ``Specific test``() = async {
         {
             new DataHelpers.IGetPriceHistory with 
                 member this.GetPriceHistory start ``end`` ticker = task {
-                    return [||] |> core.fs.Adapters.Stocks.PriceBars |> core.fs.ServiceResponse<core.fs.Adapters.Stocks.PriceBars>
+                    return [||] |> core.fs.Adapters.Stocks.PriceBars |> Ok
                 }
         }
         


### PR DESCRIPTION
When the app was rewritten from C# to F#, I kept ServiceResult type that was used for all the service call responses as a wrapper for two pieces of data: result of the call, or an error type if it failed. F# has built-in Result class and various utility functions around it that make the code more readable. Migrated the code base to that approach and deleted service result.