### PR TITLE
fix: correct off-by-one date display caused by UTC/local timezone mismatch

### DIFF
--- a/src/core.fs/Alerts/Reminders.fs
+++ b/src/core.fs/Alerts/Reminders.fs
@@ -59,7 +59,7 @@ module Reminder =
 type ReminderDto = {
     ReminderId: string
     UserId: string
-    Date: DateTimeOffset
+    Date: string  // Serialized as "yyyy-MM-dd" to avoid timezone shifting on the frontend
     Message: string
     Ticker: string option
     State: string
@@ -72,7 +72,7 @@ module ReminderDto =
         {
             ReminderId = reminder.ReminderId.ToString()
             UserId = reminder.UserId |> IdentifierHelper.getUserId |> string
-            Date = reminder.Date
+            Date = reminder.Date.ToString("yyyy-MM-dd")
             Message = reminder.Message
             Ticker = reminder.Ticker |> Option.map (fun (t:Ticker) -> t.Value)
             State = ReminderState.toString reminder.State

--- a/src/frontend/src/app/alerts/reminder-list.component.html
+++ b/src/frontend/src/app/alerts/reminder-list.component.html
@@ -32,7 +32,7 @@
             @for (reminder of reminders; track reminder.reminderId) {
               <tr [class.table-warning]="isOverdue(reminder)">
                 <td class="ps-4 py-3">
-                  <div>{{ reminder.date | date:'mediumDate' }}</div>
+                  <div>{{ reminder.date | date:'mediumDate':'UTC' }}</div>
                   @if (isOverdue(reminder)) {
                     <span class="badge bg-danger">Overdue</span>
                   }

--- a/src/frontend/src/app/alerts/reminder-list.component.ts
+++ b/src/frontend/src/app/alerts/reminder-list.component.ts
@@ -29,6 +29,9 @@ export class ReminderListComponent {
   }
 
   isOverdue(reminder: Reminder): boolean {
-    return reminder.state === 'pending' && new Date(reminder.date) < new Date();
+    if (reminder.state !== 'pending') return false;
+    // Compare date strings in 'YYYY-MM-DD' format (ISO lexicographic comparison is valid)
+    const todayStr = new Date().toLocaleDateString('en-CA'); // returns 'YYYY-MM-DD' in local time
+    return reminder.date < todayStr;
   }
 }

--- a/src/frontend/src/app/options/option-dashboard/option-brokerage-positions.component.html
+++ b/src/frontend/src/app/options/option-dashboard/option-brokerage-positions.component.html
@@ -62,7 +62,7 @@
                                         }
                                     </div>
                                 </td>
-                                <td>{{ position.expirationDate | date }}</td>
+                                <td>{{ position.expirationDate | date:'mediumDate':'UTC' }}</td>
                                 <td>
                                 </td>
                             </tr>

--- a/src/frontend/src/app/ownership/ownership-by-entity.component.html
+++ b/src/frontend/src/app/ownership/ownership-by-entity.component.html
@@ -75,8 +75,8 @@
                         {{ role.isActive ? 'Active' : 'Inactive' }}
                       </span>
                     </td>
-                    <td>{{ role.firstSeen | date }}</td>
-                    <td>{{ role.lastSeen | date }}</td>
+                    <td>{{ role.firstSeen | date:'mediumDate':'UTC' }}</td>
+                    <td>{{ role.lastSeen | date:'mediumDate':'UTC' }}</td>
                   </tr>
                 }
               </tbody>
@@ -109,7 +109,7 @@
               <tbody>
                 @for (event of events; track event.id) {
                   <tr>
-                    <td>{{ event.transactionDate | date }}</td>
+                    <td>{{ event.transactionDate | date:'mediumDate':'UTC' }}</td>
                     <td>
                       <app-stock-link-and-tradingview-link [ticker]="event.companyTicker"></app-stock-link-and-tradingview-link>
                       <a [routerLink]="['/ownership/ticker', event.companyTicker]" class="ms-2 small text-muted" title="View ownership for {{ event.companyTicker }}">ownership</a>

--- a/src/frontend/src/app/ownership/ownership-by-ticker.component.html
+++ b/src/frontend/src/app/ownership/ownership-by-ticker.component.html
@@ -153,7 +153,7 @@
                     <tr>
                       <td class="ps-4 py-3">
                         <div>{{ event.transactionDate | timeAgo }}</div>
-                        <div class="small text-muted">{{ event.transactionDate | date }}</div>
+                        <div class="small text-muted">{{ event.transactionDate | date:'mediumDate':'UTC' }}</div>
                       </td>
                       <td class="py-3">
                         <a [routerLink]="['/ownership/entity', event.entityId]">

--- a/src/frontend/src/app/ownership/ownership-home.component.html
+++ b/src/frontend/src/app/ownership/ownership-home.component.html
@@ -136,7 +136,7 @@
                       @for (timeline of recentTimelines; track timeline.id) {
                         <tr>
                           <td class="ps-4 py-3">
-                            <div>{{ timeline.filingDate | date:'mediumDate' }}</div>
+                            <div>{{ timeline.filingDate | date:'mediumDate':'UTC' }}</div>
                             <div class="small text-muted">{{ timeline.createdAt | timeAgo }}</div>
                           </td>
                           <td class="py-3">

--- a/src/frontend/src/app/recentsells/recentsells.component.html
+++ b/src/frontend/src/app/recentsells/recentsells.component.html
@@ -18,7 +18,7 @@
                         <td>
                             <app-stock-link class="text-white" [ticker]="s.ticker"></app-stock-link>
                         </td>
-                        <td>{{ s.date | date }}</td>
+                        <td>{{ s.date | date:'mediumDate':'UTC' }}</td>
                         <td>{{ s.numberOfShares }}</td>
                         <td>{{ s.price }}</td>
                         <td>{{ s.currentPrice }}</td>

--- a/src/frontend/src/app/reports/failuresuccesschain/failuresuccesschain/failuresuccesschain.component.html
+++ b/src/frontend/src/app/reports/failuresuccesschain/failuresuccesschain/failuresuccesschain.component.html
@@ -22,7 +22,7 @@
         <ul>
             @for (link of chain.links; track link) {
                 <span
-                    title="{{link.ticker}} level {{ link.level }} profit: {{ link.profit | currency }} on {{ link.date | date: 'shortDate' }}"
+                    title="{{link.ticker}} level {{ link.level }} profit: {{ link.profit | currency }} on {{ link.date | date:'shortDate':'UTC' }}"
                     class="badge me-2 text-white"
                     [ngClass]="{
             'bg-level-5-success': link.success && link.level === 5 && (render === 'all' || render === 'success'),

--- a/src/frontend/src/app/shared/reports/gaps.component.html
+++ b/src/frontend/src/app/shared/reports/gaps.component.html
@@ -23,7 +23,7 @@
                                 [ngClass]="{'bg-success': g.type === 'Up', 'bg-secondary': g.type === 'Down', 'text-white': true, 'bi': true, 'bi-arrow-up-circle': g.type === 'Up', 'bi-arrow-down-circle': g.type === 'Down'}"
                                 class="ps-2 pe-2">
                             </i>
-                            {{ g.bar.dateStr | date }}
+                            {{ g.bar.dateStr | date:'mediumDate':'UTC' }}
                         </td>
                         <td>{{ g.gapSizePct | percent:'1.2-2' }}</td>
                         <td>{{ g.percentChange | percent:'1.2-2' }}</td>

--- a/src/frontend/src/app/shared/sec/sec-filings-table.component.html
+++ b/src/frontend/src/app/shared/sec/sec-filings-table.component.html
@@ -75,8 +75,8 @@
                 </tr>
               } @else {
                 <tr>
-                  <td class="text-muted">{{ row.filing!.filingDate | date:'mediumDate' }}</td>
-                  <td class="text-muted">{{ row.filing!.reportDate ? (row.filing!.reportDate | date:'mediumDate') : 'N/A' }}</td>
+                  <td class="text-muted">{{ row.filing!.filingDate | date:'mediumDate':'UTC' }}</td>
+                  <td class="text-muted">{{ row.filing!.reportDate ? (row.filing!.reportDate | date:'mediumDate':'UTC') : 'N/A' }}</td>
                   <td>
                     <span class="badge bg-primary">{{ row.filing!.filing }}</span>
                   </td>

--- a/src/frontend/src/app/shared/stock-daily-scores/stock-daily-scores.component.html
+++ b/src/frontend/src/app/shared/stock-daily-scores/stock-daily-scores.component.html
@@ -17,7 +17,7 @@
             <input
               type="date"
               class="form-control border-start-0 ps-0"
-              [ngModel]="selectedStartDate | date:'yyyy-MM-dd'"
+              [ngModel]="selectedStartDate | date:'yyyy-MM-dd':'UTC'"
               (ngModelChange)="onStartDateChange($event)"
               aria-label="Select start date">
             </div>
@@ -34,7 +34,7 @@
               <input
                 type="date"
                 class="form-control border-start-0 ps-0"
-                [ngModel]="selectedEndDate | date:'yyyy-MM-dd'"
+                [ngModel]="selectedEndDate | date:'yyyy-MM-dd':'UTC'"
                 (ngModelChange)="onEndDateChange($event)"
                 aria-label="Select end date">
               </div>

--- a/src/frontend/src/app/stocks/stock-details/stock-analysis.component.html
+++ b/src/frontend/src/app/stocks/stock-details/stock-analysis.component.html
@@ -6,7 +6,7 @@
           <i class="bi bi-graph-up me-2"></i>Chart
         </h5>
         <div class="text-muted">
-          <small>{{startDate | date:'mediumDate'}} - {{endDate | date:'mediumDate'}}</small>
+          <small>{{startDate | date:'mediumDate':'UTC'}} - {{endDate | date:'mediumDate':'UTC'}}</small>
         </div>
       </div>
     </div>

--- a/src/frontend/src/app/stocks/stock-details/stock-fundamentals.component.html
+++ b/src/frontend/src/app/stocks/stock-details/stock-fundamentals.component.html
@@ -233,7 +233,7 @@
                     <div class="col">
                         <div class="metric-card">
                             <div class="metric-name">Dividend Date</div>
-                            <div class="metric-value">{{ profile.fundamentals['dividendDate'] | date }}</div>
+                            <div class="metric-value">{{ profile.fundamentals['dividendDate'] | date:'mediumDate':'UTC' }}</div>
                         </div>
                     </div>
                     <div class="col">

--- a/src/frontend/src/app/stocks/stock-trading-review/stock-trading-closed-positions.component.html
+++ b/src/frontend/src/app/stocks/stock-trading-review/stock-trading-closed-positions.component.html
@@ -102,8 +102,8 @@
                                             <app-trading-view-link [ticker]="position.ticker"></app-trading-view-link>
                                             <app-stock-link [ticker]="position.ticker"></app-stock-link>
                                         </div>
-                                        <div class="col">{{ position.opened | date:'shortDate' }}</div>
-                                        <div class="col">{{ position.closed | date:'shortDate' }}</div>
+                                        <div class="col">{{ position.opened | date:'shortDate':'UTC' }}</div>
+                                        <div class="col">{{ position.closed | date:'shortDate':'UTC' }}</div>
                                         <div class="col">{{ position.rr | number:'1.0-2' }}</div>
                                         <div class="col">{{ position.profit | currency }}</div>
                                         <div class="col">{{ position.grade }}</div>
@@ -127,8 +127,8 @@
                                             <app-trading-view-link [ticker]="position.ticker"></app-trading-view-link>
                                             <app-stock-link [ticker]="position.ticker"></app-stock-link>
                                         </div>
-                                        <div class="col">{{ position.opened | date:'shortDate' }}</div>
-                                        <div class="col">{{ position.closed | date:'shortDate' }}</div>
+                                        <div class="col">{{ position.opened | date:'shortDate':'UTC' }}</div>
+                                        <div class="col">{{ position.closed | date:'shortDate':'UTC' }}</div>
                                         <div class="col">{{ position.rr | number:'1.0-2' }}</div>
                                         <div class="col">{{ position.profit | currency }}</div>
                                         <div class="col">{{ position.grade }}</div>
@@ -165,7 +165,7 @@
                             @if (i === 0 || getPropertyForSeperatorGrouping(p) !== getPropertyForSeperatorGrouping(positions[i - 1])) {
                                 <tr>
                                     <td colspan="3" class="text-center fw-bold pt-3">
-                                        {{ getPropertyForSeperatorGrouping(p) | date:'MMMM yyyy' }}
+                                        {{ getPropertyForSeperatorGrouping(p) | date:'MMMM yyyy':'UTC' }}
                                     </td>
                                     <td class="pt-3 pb-3">R:R Sum <span
                                         class="fw-bold">{{ getRRSumForMonth(p) | number }}</span></td>
@@ -196,8 +196,8 @@
                                         <app-trading-view-link [ticker]="p.ticker"></app-trading-view-link>
                                         <app-stock-link [ticker]="p.ticker"></app-stock-link>
                                     </td>
-                                    <td>{{ p.opened | date }}</td>
-                                    <td>{{ p.closed | date }}</td>
+                                    <td>{{ p.opened | date:'mediumDate':'UTC' }}</td>
+                                    <td>{{ p.closed | date:'mediumDate':'UTC' }}</td>
                                     <td>{{ p.daysHeld }}</td>
                                     <td>{{ p.rr | number:'1.0-2' }}</td>
                                     <td>{{ p.profit | currency }}</td>

--- a/src/frontend/src/app/stocks/stock-trading/stock-trading-simulations.component.html
+++ b/src/frontend/src/app/stocks/stock-trading/stock-trading-simulations.component.html
@@ -21,8 +21,8 @@
       <div class="row mb-3">
         <div class="col-10">
           <div>
-            <span class="text-muted">Earliest date:</span> {{ results[0].performance.earliestDate | date }},
-            <span class="text-muted">latest date:</span> {{ results[0].performance.latestDate | date }}
+            <span class="text-muted">Earliest date:</span> {{ results[0].performance.earliestDate | date:'mediumDate':'UTC' }},
+            <span class="text-muted">latest date:</span> {{ results[0].performance.latestDate | date:'mediumDate':'UTC' }}
           </div>
         </div>
         <div class="col-2">

--- a/src/frontend/src/app/stocks/stock-trading/stock-trading-simulator.component.html
+++ b/src/frontend/src/app/stocks/stock-trading/stock-trading-simulator.component.html
@@ -33,7 +33,7 @@
               (click)="loadPosition(position)">
               <div>
                 <span class="fw-bold">{{ position.ticker }}</span>
-                <small class="text-muted ms-2">{{ position.opened | date:'mediumDate' }}</small>
+                <small class="text-muted ms-2">{{ position.opened | date:'mediumDate':'UTC' }}</small>
               </div>
               <span [class]="position.profit >= 0 ? 'profit-positive' : 'profit-negative'">
                 {{ position.profit | currency }}
@@ -139,7 +139,7 @@
                         @for (p of transactions; track p; let i = $index) {
                           <div class="transaction-row d-flex justify-content-between align-items-center">
                             <div class="d-flex align-items-center">
-                              <span class="me-3">{{ p.date | date:'shortDate' }}</span>
+                              <span class="me-3">{{ p.date | date:'shortDate':'UTC' }}</span>
                               <span class="badge bg-light text-dark me-3">{{ p.type }}</span>
                               <span class="me-3">{{ p.price | currency }}</span>
                               <span class="me-3">{{ p.numberOfShares | number }} shares</span>

--- a/src/frontend/src/app/summary/summary.component.html
+++ b/src/frontend/src/app/summary/summary.component.html
@@ -7,7 +7,7 @@
     <div class="row mb-4">
       <div class="col-12">
         <div class="d-flex justify-content-between align-items-center">
-          <h2 class="m-0">Week of {{ result.start | date }} Review</h2>
+          <h2 class="m-0">Week of {{ result.start | date:'mediumDate':'UTC' }} Review</h2>
           <select class="form-select w-auto" [(ngModel)]="timePeriod" (ngModelChange)="periodChanged()">
             <option value="thisweek" selected>This week</option>
             <option value="last7days">Last 7 days</option>
@@ -164,7 +164,7 @@
                   <td>{{ p.isShort ? "SHORT" : "LONG" }}</td>
                   <td>{{ p.completedPositionShares }}</td>
                   <td>{{ p.completedPositionCostPerShare * p.completedPositionShares | number:'1.0-2' }}</td>
-                  <td>{{ p.opened | date: 'MM/dd/yyyy' }}</td>
+                  <td>{{ p.opened | date:'MM/dd/yyyy':'UTC' }}</td>
                 </tr>
               }
               @empty {
@@ -198,7 +198,7 @@
                 </td>
                 <td>{{ p.numberOfShares }}</td>
                 <td [ngClass]="{'negative': p.profit < 0}">{{ p.profit | currency }}</td>
-                <td>{{ p.date | date: 'MM/dd/yyyy' }}</td>
+                <td>{{ p.date | date:'MM/dd/yyyy':'UTC' }}</td>
               </tr>
               } @empty {
               <tr>
@@ -227,7 +227,7 @@
                   <app-trading-view-link [ticker]="g.underlyingTicker"></app-trading-view-link>
                   <app-stock-link [ticker]="g.underlyingTicker" [openInNewTab]="true"></app-stock-link>
                 </td>
-                <td>{{ g.opened | date }}</td>
+                <td>{{ g.opened | date:'mediumDate':'UTC' }}</td>
                 <td>{{ g.cost | currency }}</td>
               </tr>
             }
@@ -260,8 +260,8 @@
                 <app-stock-link [ticker]="g.underlyingTicker" [openInNewTab]="true"></app-stock-link>
               </td>
               <td>{{ g.profit | currency }}</td>
-              <td>{{ g.opened | date }}</td>
-              <td>{{ g.closed | date }}</td>
+              <td>{{ g.opened | date:'mediumDate':'UTC' }}</td>
+              <td>{{ g.closed | date:'mediumDate':'UTC' }}</td>
             </tr>
           }
           @empty {
@@ -285,7 +285,7 @@
               <app-stock-link [ticker]="g.ticker" [openInNewTab]="true"></app-stock-link>
             </td>
             <td style="width: 140px">{{ g.netAmount | currency }}</td>
-            <td style="width: 140px">{{ g.date | date }}</td>
+            <td style="width: 140px">{{ g.date | date:'mediumDate':'UTC' }}</td>
             <td>{{ g.description }}</td>
           </tr>
         }
@@ -310,7 +310,7 @@
               <app-stock-link [ticker]="g.ticker" [openInNewTab]="true"></app-stock-link>
             </td>
             <td style="width: 140px">{{ g.netAmount | currency }}</td>
-            <td style="width: 140px">{{ g.date | date }}</td>
+            <td style="width: 140px">{{ g.date | date:'mediumDate':'UTC' }}</td>
             <td>{{ g.description }}</td>
           </tr>
         }

--- a/src/frontend/src/app/transactions/transactions.component.html
+++ b/src/frontend/src/app/transactions/transactions.component.html
@@ -167,7 +167,7 @@
                             <tbody>
                                 @for (t of g.transactions; track t) {
                                     <tr>
-                                        <td class="ps-4">{{ t.date | date:'shortDate' }}</td>
+                                        <td class="ps-4">{{ t.date | date:'shortDate':'UTC' }}</td>
                                         <td>
                                             @if (t.isOption) {
                                                 <a [routerLink]="[ '/optiondetails', t.aggregateId ]"


### PR DESCRIPTION
Root cause: Calendar date fields stored as DateTimeOffset at UTC midnight (e.g. 2026-02-28T00:00:00+00:00) were rendered by Angular's DatePipe using the browser's local timezone. For US users (UTC-5), midnight UTC on Feb 28 displayed as Feb 27 local time - one day off.

Changes:
- backend: ReminderDto.Date changed from DateTimeOffset to string (yyyy-MM-dd)
  to avoid timezone ambiguity in the API response
- frontend: isOverdue() in reminder-list now uses local date string comparison
  instead of Date object comparison to correctly reflect local calendar day
- frontend: all | date pipe usages for calendar date fields now include 'UTC' as the timezone argument, ensuring UTC midnight dates display on the correct calendar day across the whole app

Files fixed (19):   Reminders.fs, reminder-list component, transactions, summary, recentsells,   stock-trading-simulator/simulations, stock-analysis, stock-fundamentals,   stock-trading-closed-positions, sec-filings-table, stock-daily-scores,   gaps, failuresuccesschain, ownership-home/by-ticker/by-entity,   option-brokerage-positions